### PR TITLE
Do not require the user to cast the code behind class.

### DIFF
--- a/mvvmfx-cdi-example/src/main/java/de/saxsys/jfx/App.java
+++ b/mvvmfx-cdi-example/src/main/java/de/saxsys/jfx/App.java
@@ -8,6 +8,7 @@ import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
 import de.saxsys.jfx.exampleapplication.view.maincontainer.MainContainerView;
+import de.saxsys.jfx.mvvm.base.viewmodel.ViewModel;
 import de.saxsys.jfx.mvvm.di.cdi.StartupEvent;
 import de.saxsys.jfx.mvvm.viewloader.ViewLoader;
 import de.saxsys.jfx.mvvm.viewloader.ViewTuple;
@@ -32,7 +33,7 @@ public class App {
 	public void startApplication(@Observes StartupEvent startupEvent) {
 		Stage stage = startupEvent.getPrimaryStage();
 
-		final ViewTuple tuple = viewLoader
+		final ViewTuple<ViewModel> tuple = viewLoader
 				.loadViewTuple(MainContainerView.class);
 		// Locate View for loaded FXML file
 		final Parent view = tuple.getView();

--- a/mvvmfx-guice-example/src/main/java/de/saxsys/jfx/Starter.java
+++ b/mvvmfx-guice-example/src/main/java/de/saxsys/jfx/Starter.java
@@ -10,6 +10,7 @@ import com.google.inject.Inject;
 import com.google.inject.Module;
 
 import de.saxsys.jfx.exampleapplication.view.maincontainer.MainContainerView;
+import de.saxsys.jfx.mvvm.base.viewmodel.ViewModel;
 import de.saxsys.jfx.mvvm.di.guice.MvvmGuiceApplication;
 import de.saxsys.jfx.mvvm.viewloader.ViewLoader;
 import de.saxsys.jfx.mvvm.viewloader.ViewTuple;
@@ -32,7 +33,7 @@ public class Starter extends MvvmGuiceApplication {
 
 	@Override
 	public void start(final Stage stage) throws Exception {
-		final ViewTuple tuple = viewLoader
+		final ViewTuple<ViewModel> tuple = viewLoader
 				.loadViewTuple(MainContainerView.class);
 		// Locate View for loaded FXML file
 		final Parent view = tuple.getView();

--- a/mvvmfx/src/main/java/de/saxsys/jfx/mvvm/viewloader/ViewLoader.java
+++ b/mvvmfx/src/main/java/de/saxsys/jfx/mvvm/viewloader/ViewLoader.java
@@ -27,8 +27,8 @@ import javafx.scene.Parent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 import de.saxsys.jfx.mvvm.base.view.View;
+import de.saxsys.jfx.mvvm.base.viewmodel.ViewModel;
 import de.saxsys.jfx.mvvm.di.FXMLLoaderWrapper;
 
 /**
@@ -59,11 +59,11 @@ public final class ViewLoader {
 	 *            which is the code behind of a fxml
 	 * @return the tuple
 	 */
-	public ViewTuple loadViewTuple(
-			@SuppressWarnings("rawtypes") Class<? extends View> clazz) {
+	public <ViewType extends ViewModel> ViewTuple<ViewType> loadViewTuple(
+			Class<? extends View> ViewType) {
 		String pathToFXML = "/"
-				+ clazz.getPackage().getName().replaceAll("\\.", "/") + "/"
-				+ clazz.getSimpleName() + ".fxml";
+				+ ViewType.getPackage().getName().replaceAll("\\.", "/") + "/"
+				+ ViewType.getSimpleName() + ".fxml";
 
 		return loadViewTuple(pathToFXML);
 	}

--- a/mvvmfx/src/main/java/de/saxsys/jfx/mvvm/viewloader/ViewTuple.java
+++ b/mvvmfx/src/main/java/de/saxsys/jfx/mvvm/viewloader/ViewTuple.java
@@ -17,14 +17,15 @@ package de.saxsys.jfx.mvvm.viewloader;
  */
 import javafx.scene.Parent;
 import de.saxsys.jfx.mvvm.base.view.View;
+import de.saxsys.jfx.mvvm.base.viewmodel.ViewModel;
 
 /**
  * Tuple for carrying view / code-behind pair. The code-behind part is the class
  * which is known as the controller class behind a FXML file.
  */
-public class ViewTuple {
+public class ViewTuple <ViewModelType extends ViewModel> {
 
-	private final View<?> codeBehind;
+	private final View<ViewModelType> codeBehind;
 	private final Parent view;
 
 	/**
@@ -33,7 +34,7 @@ public class ViewTuple {
 	 * @param view
 	 *            to set
 	 */
-	public ViewTuple(final View<?> codeBehind, final Parent view) {
+	public ViewTuple(final View<ViewModelType> codeBehind, final Parent view) {
 		this.codeBehind = codeBehind;
 		this.view = view;
 	}
@@ -42,7 +43,7 @@ public class ViewTuple {
 	 * @return the code behind of the FXML File (known as controller class in
 	 *         JavaFX)
 	 */
-	public View<?> getCodeBehind() {
+	public View<ViewModelType> getCodeBehind() {
 		return codeBehind;
 	}
 


### PR DESCRIPTION
This patch allows the user to get an instance of the code behind class without needing to cast it manually to the correct class. Unfortunately, at the current state this patch provokes many "raw type" warnings in the framework. Maybe someone is in the mood to fix them. ;-)

User code can be written without these warnings, though.
