### PR TITLE
#78 access view model

### DIFF
--- a/mvvmfx/src/main/java/de/saxsys/jfx/mvvm/viewloader/DependencyInjector.java
+++ b/mvvmfx/src/main/java/de/saxsys/jfx/mvvm/viewloader/DependencyInjector.java
@@ -86,23 +86,24 @@ public class DependencyInjector {
 		final Field field = getViewModelField(view.getClass(), viewModelType);
 		
 		if (field != null) {
-			AccessController.doPrivileged(new PrivilegedAction<Object>() {
-				@Override
-				public Object run() {
-					boolean wasAccessible = field.isAccessible();
+			AccessController.doPrivileged((PrivilegedAction<Object>) () -> {
+				boolean wasAccessible = field.isAccessible();
+				
+				try {
+					Object existingViewModel = field.get(view);
 					
-					try {
+					if(existingViewModel == null){
 						Object viewModel = DependencyInjector.getInstance().getInstanceOf(viewModelType);
 						field.setAccessible(true);
 						field.set(view, viewModel);
-					} catch (IllegalAccessException exception) {
-						throw new IllegalStateException("Can't inject ViewModel of type <" + viewModelType
-								+ "> into the view <" + view + ">");
-					} finally {
-						field.setAccessible(wasAccessible);
 					}
-					return null;
+				} catch (IllegalAccessException exception) {
+					throw new IllegalStateException("Can't inject ViewModel of type <" + viewModelType
+							+ "> into the view <" + view + ">");
+				} finally {
+					field.setAccessible(wasAccessible);
 				}
+				return null;
 			});
 		}
 		

--- a/mvvmfx/src/main/java/de/saxsys/jfx/mvvm/viewloader/FxmlViewLoader.java
+++ b/mvvmfx/src/main/java/de/saxsys/jfx/mvvm/viewloader/FxmlViewLoader.java
@@ -57,7 +57,7 @@ class FxmlViewLoader {
 			
 			loader.load();
 			
-			final View loadedController = loader.getController();
+			final ViewType loadedController = loader.getController();
 			final Parent loadedRoot = loader.getRoot();
 			
 			if (loadedController == null) {
@@ -65,7 +65,9 @@ class FxmlViewLoader {
 						+ " maybe your missed the fx:controller in your fxml?");
 			}
 			
-			return new ViewTuple(loadedController, loadedRoot);
+			final ViewModelType viewModel = DependencyInjector.getInstance().getViewModel(loadedController);
+			
+			return new ViewTuple(loadedController, loadedRoot, viewModel);
 			
 		} catch (final IOException ex) {
 			throw new RuntimeException(ex);

--- a/mvvmfx/src/main/java/de/saxsys/jfx/mvvm/viewloader/JavaViewLoader.java
+++ b/mvvmfx/src/main/java/de/saxsys/jfx/mvvm/viewloader/JavaViewLoader.java
@@ -78,8 +78,10 @@ class JavaViewLoader {
 			injectResourceBundle(view, resourceBundle);
 			callInitialize(view);
 		}
-		
-		return new ViewTuple<>(view, (Parent) view);
+
+		final ViewModelType viewModel = DependencyInjector.getInstance().getViewModel(view);
+
+		return new ViewTuple<>(view, (Parent) view, viewModel);
 	}
 	
 	/**

--- a/mvvmfx/src/main/java/de/saxsys/jfx/mvvm/viewloader/ViewTuple.java
+++ b/mvvmfx/src/main/java/de/saxsys/jfx/mvvm/viewloader/ViewTuple.java
@@ -28,6 +28,7 @@ public class ViewTuple<ViewType extends View<? extends ViewModelType>, ViewModel
 	
 	private final ViewType codeBehind;
 	private final Parent view;
+	private final ViewModelType viewModel;
 	
 	/**
 	 * @param codeBehind
@@ -35,13 +36,14 @@ public class ViewTuple<ViewType extends View<? extends ViewModelType>, ViewModel
 	 * @param view
 	 *            to set
 	 */
-	public ViewTuple(final ViewType codeBehind, final Parent view) {
+	public ViewTuple(final ViewType codeBehind, final Parent view, final ViewModelType viewModel) {
 		this.codeBehind = codeBehind;
 		this.view = view;
+		this.viewModel = viewModel;
 	}
 	
 	/**
-	 * @return the code behind of the FXML File (known as controller class in JavaFX)
+	 * @return the code behind of the View. (known as controller class in JavaFX FXML)
 	 */
 	public ViewType getCodeBehind() {
 		return codeBehind;
@@ -52,5 +54,12 @@ public class ViewTuple<ViewType extends View<? extends ViewModelType>, ViewModel
 	 */
 	public Parent getView() {
 		return view;
+	}
+
+	/**
+	 * @return the viewModel
+	 */
+	public ViewModelType getViewModel(){
+		return viewModel;
 	}
 }

--- a/mvvmfx/src/test/java/de/saxsys/jfx/mvvm/viewloader/ViewLoaderIntegrationTest.java
+++ b/mvvmfx/src/test/java/de/saxsys/jfx/mvvm/viewloader/ViewLoaderIntegrationTest.java
@@ -17,6 +17,8 @@ package de.saxsys.jfx.mvvm.viewloader;
 
 import static org.assertj.core.api.Assertions.*;
 
+import de.saxsys.jfx.mvvm.viewloader.example.TestFxmlViewWithMissingController;
+import javafx.fxml.LoadException;
 import javafx.scene.layout.VBox;
 
 import org.junit.Before;
@@ -119,4 +121,71 @@ public class ViewLoaderIntegrationTest {
 		assertThat(viewTuple.getView()).isNotNull();
 		assertThat(viewTuple.getCodeBehind()).isNotNull();
 	}
+
+	/**
+	 * It is possible to use an existing instance of the codeBehind/controller. 
+	 */
+	@Test
+	public void testUseExistingCodeBehind(){
+
+		TestFxmlViewWithMissingController codeBehind = new TestFxmlViewWithMissingController();
+
+		viewLoader.setCodeBehind(codeBehind);
+
+		ViewTuple<TestFxmlViewWithMissingController, TestViewModel> viewTuple = viewLoader
+				.loadViewTuple(TestFxmlViewWithMissingController.class);
+
+		assertThat(viewTuple).isNotNull();
+
+		assertThat(viewTuple.getCodeBehind()).isEqualTo(codeBehind);
+		assertThat(viewTuple.getCodeBehind().viewModel).isNotNull();
+	}
+
+	/**
+	 * When there is already a Controller defined in the fxml file (fx:controller) then
+	 * it is not possible to use an existing controller instance with the viewLoader. 
+	 */
+	@Test
+	public void testUseExistingCodeBehindFailWhenControllerIsDefinedInFXML() {
+		
+		try {
+			TestFxmlView codeBehind = new TestFxmlView(); // the fxml file for this class has a fx:controller defined.
+			
+			viewLoader.setCodeBehind(codeBehind);
+
+			ViewTuple<TestFxmlView, TestViewModel> viewTuple = viewLoader
+					.loadViewTuple(TestFxmlView.class);
+			
+			fail("Expected a LoadException to be thrown");
+		}catch(Exception e) {
+			assertThat(e).hasCauseInstanceOf(LoadException.class).hasMessageContaining(
+					"Controller value already specified");
+		}
+	}
+
+
+	/**
+	 * The user can define a codeBehind instance that should be used by the viewLoader.
+	 * When this codeBehind instance has already has a ViewModel it should not be overwritten when the view is loaded.
+	 */
+	@Test
+	public void testAlreadyExistingViewModelShouldNotBeOverwritten(){
+
+		TestFxmlViewWithMissingController codeBehind = new TestFxmlViewWithMissingController();
+		
+		TestViewModel existingViewModel = new TestViewModel();
+		
+		codeBehind.viewModel = existingViewModel;
+		
+		viewLoader.setCodeBehind(codeBehind);
+
+		ViewTuple<TestFxmlViewWithMissingController, TestViewModel> viewTuple = viewLoader
+				.loadViewTuple(TestFxmlViewWithMissingController.class);
+
+		assertThat(viewTuple.getCodeBehind()).isNotNull();
+		assertThat(viewTuple.getCodeBehind().viewModel).isEqualTo(existingViewModel);
+
+	}
+
 }
+

--- a/mvvmfx/src/test/java/de/saxsys/jfx/mvvm/viewloader/ViewLoaderIntegrationTest.java
+++ b/mvvmfx/src/test/java/de/saxsys/jfx/mvvm/viewloader/ViewLoaderIntegrationTest.java
@@ -184,8 +184,31 @@ public class ViewLoaderIntegrationTest {
 
 		assertThat(viewTuple.getCodeBehind()).isNotNull();
 		assertThat(viewTuple.getCodeBehind().viewModel).isEqualTo(existingViewModel);
-
 	}
 
+	
+	@Test
+	public void testViewModelIsAvailableInViewTupleForFXMLView(){
+
+		ViewTuple<TestFxmlView, TestViewModel> viewTuple = viewLoader
+				.loadViewTuple(TestFxmlView.class);
+
+		TestViewModel viewModel = viewTuple.getViewModel();
+		
+		assertThat(viewModel).isNotNull();
+		assertThat(viewModel).isEqualTo(viewTuple.getCodeBehind().viewModel);
+	}
+	
+	@Test
+	public void testViewModelIsAvailableInViewTupleForJavaView(){
+
+		ViewTuple<TestJavaView, TestViewModel> viewTuple = viewLoader
+				.loadViewTuple(TestJavaView.class);
+
+		TestViewModel viewModel = viewTuple.getViewModel();
+		
+		assertThat(viewModel).isNotNull();
+		assertThat(viewModel).isEqualTo(viewTuple.getCodeBehind().viewModel);
+	}
 }
 

--- a/mvvmfx/src/test/java/de/saxsys/jfx/mvvm/viewloader/example/TestFxmlViewWithMissingController.java
+++ b/mvvmfx/src/test/java/de/saxsys/jfx/mvvm/viewloader/example/TestFxmlViewWithMissingController.java
@@ -1,7 +1,10 @@
 package de.saxsys.jfx.mvvm.viewloader.example;
 
 import de.saxsys.jfx.mvvm.api.FxmlView;
+import de.saxsys.jfx.mvvm.api.InjectViewModel;
 
-public class TestFxmlViewWithMissingController implements FxmlView {
+public class TestFxmlViewWithMissingController implements FxmlView<TestViewModel> {
 	
+	@InjectViewModel
+	public TestViewModel viewModel;
 }


### PR DESCRIPTION
Fixed problem with overwritten ViewModel when an existing instance of the view is set as CodeBehind.

The ViewModel can now be accesses in the ViewTuple.
#78
