### PR TITLE
#102 The view in ViewTuple is now of type Node instead of Parent. This w...

### DIFF
--- a/mvvmfx/src/main/java/de/saxsys/jfx/mvvm/viewloader/FxmlViewLoader.java
+++ b/mvvmfx/src/main/java/de/saxsys/jfx/mvvm/viewloader/FxmlViewLoader.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.ResourceBundle;
 import javafx.fxml.FXMLLoader;
+import javafx.scene.Node;
 import javafx.scene.Parent;
 
 import org.slf4j.Logger;
@@ -58,7 +59,7 @@ class FxmlViewLoader {
 			loader.load();
 			
 			final ViewType loadedController = loader.getController();
-			final Parent loadedRoot = loader.getRoot();
+			final Node loadedRoot = loader.getRoot();
 			
 			if (loadedController == null) {
 				throw new IOException("Could not load the controller for the View " + resource

--- a/mvvmfx/src/main/java/de/saxsys/jfx/mvvm/viewloader/JavaViewLoader.java
+++ b/mvvmfx/src/main/java/de/saxsys/jfx/mvvm/viewloader/JavaViewLoader.java
@@ -20,6 +20,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ResourceBundle;
 import javafx.fxml.Initializable;
+import javafx.scene.Node;
 import javafx.scene.Parent;
 
 import org.slf4j.Logger;
@@ -71,6 +72,11 @@ class JavaViewLoader {
 		
 		final ViewType view = injectionFacade.getInstanceOf(viewType);
 		
+		if(!(view instanceof Node)){
+			throw new IllegalArgumentException("The view class has to be a subclass of 'javafx.scene.Node'");
+		}
+		
+		
 		if (view instanceof Initializable) {
 			Initializable initializable = (Initializable) view;
 			initializable.initialize(null, resourceBundle);
@@ -80,8 +86,8 @@ class JavaViewLoader {
 		}
 
 		final ViewModelType viewModel = DependencyInjector.getInstance().getViewModel(view);
-
-		return new ViewTuple<>(view, (Parent) view, viewModel);
+		
+		return new ViewTuple<>(view, (Node) view, viewModel);
 	}
 	
 	/**

--- a/mvvmfx/src/main/java/de/saxsys/jfx/mvvm/viewloader/ViewTuple.java
+++ b/mvvmfx/src/main/java/de/saxsys/jfx/mvvm/viewloader/ViewTuple.java
@@ -15,6 +15,7 @@
  ******************************************************************************/
 package de.saxsys.jfx.mvvm.viewloader;
 
+import javafx.scene.Node;
 import javafx.scene.Parent;
 
 import de.saxsys.jfx.mvvm.api.ViewModel;
@@ -27,7 +28,7 @@ import de.saxsys.jfx.mvvm.base.view.View;
 public class ViewTuple<ViewType extends View<? extends ViewModelType>, ViewModelType extends ViewModel> {
 	
 	private final ViewType codeBehind;
-	private final Parent view;
+	private final Node view;
 	private final ViewModelType viewModel;
 	
 	/**
@@ -36,7 +37,7 @@ public class ViewTuple<ViewType extends View<? extends ViewModelType>, ViewModel
 	 * @param view
 	 *            to set
 	 */
-	public ViewTuple(final ViewType codeBehind, final Parent view, final ViewModelType viewModel) {
+	public ViewTuple(final ViewType codeBehind, final Node view, final ViewModelType viewModel) {
 		this.codeBehind = codeBehind;
 		this.view = view;
 		this.viewModel = viewModel;
@@ -52,7 +53,7 @@ public class ViewTuple<ViewType extends View<? extends ViewModelType>, ViewModel
 	/**
 	 * @return the view
 	 */
-	public Parent getView() {
+	public Node getView() {
 		return view;
 	}
 

--- a/mvvmfx/src/test/java/de/saxsys/jfx/mvvm/viewloader/JavaViewLoaderTest.java
+++ b/mvvmfx/src/test/java/de/saxsys/jfx/mvvm/viewloader/JavaViewLoaderTest.java
@@ -22,6 +22,9 @@ import java.io.StringReader;
 import java.net.URL;
 import java.util.PropertyResourceBundle;
 import java.util.ResourceBundle;
+
+import de.saxsys.jfx.mvvm.viewloader.example.TestJavaViewExtendsNode;
+import de.saxsys.jfx.mvvm.viewloader.example.TestJavaViewNoNode;
 import javafx.fxml.Initializable;
 import javafx.scene.layout.VBox;
 
@@ -272,4 +275,35 @@ public class JavaViewLoaderTest {
 			throw new IllegalStateException("TEST");
 		}
 	}
+
+	/**
+	 * A JavaView that doesn't extend from {@link javafx.scene.Node} can't be used as view. In this case 
+	 * an Exception has to be thrown.
+	 */
+	@Test
+	public void testLoadViewThatDoesntExtendNodeShouldThrowException(){
+		try{
+			
+			ViewTuple<TestJavaViewNoNode, TestViewModel> viewTuple = javaViewLoader
+				.loadJavaViewTuple(TestJavaViewNoNode.class, null);
+			fail("Expected an expection because the view type doesn't extend Node");
+		}catch(Exception e){
+			assertThat(e).isInstanceOf(IllegalArgumentException.class).hasMessageContaining("javafx.scene.Node");
+		}
+	}
+
+
+	/**
+	 * It has to be possible to load JavaViews that aren't extending from {@link javafx.scene.Parent} but
+	 * directly from {@link javafx.scene.Node}.
+	 */
+	@Test
+	public void testLoadViewThatExtendsNodeDirectly(){
+		ViewTuple<TestJavaViewExtendsNode, TestViewModel> viewTuple = javaViewLoader
+				.loadJavaViewTuple(TestJavaViewExtendsNode.class, null);
+		
+		assertThat(viewTuple).isNotNull();
+	}
+	
 }
+ 

--- a/mvvmfx/src/test/java/de/saxsys/jfx/mvvm/viewloader/example/TestJavaViewExtendsNode.java
+++ b/mvvmfx/src/test/java/de/saxsys/jfx/mvvm/viewloader/example/TestJavaViewExtendsNode.java
@@ -1,0 +1,33 @@
+package de.saxsys.jfx.mvvm.viewloader.example;
+
+import javafx.scene.Node;
+
+import com.sun.javafx.geom.BaseBounds;
+import com.sun.javafx.geom.transform.BaseTransform;
+import com.sun.javafx.jmx.MXNodeAlgorithm;
+import com.sun.javafx.jmx.MXNodeAlgorithmContext;
+import com.sun.javafx.sg.prism.NGNode;
+import de.saxsys.jfx.mvvm.api.JavaView;
+
+public class TestJavaViewExtendsNode extends Node implements JavaView<TestViewModel> {
+	
+	@Override
+	protected NGNode impl_createPeer() {
+		return null;
+	}
+	
+	@Override
+	public BaseBounds impl_computeGeomBounds(BaseBounds bounds, BaseTransform tx) {
+		return null;
+	}
+	
+	@Override
+	protected boolean impl_computeContains(double localX, double localY) {
+		return false;
+	}
+	
+	@Override
+	public Object impl_processMXNode(MXNodeAlgorithm alg, MXNodeAlgorithmContext ctx) {
+		return null;
+	}
+}

--- a/mvvmfx/src/test/java/de/saxsys/jfx/mvvm/viewloader/example/TestJavaViewNoNode.java
+++ b/mvvmfx/src/test/java/de/saxsys/jfx/mvvm/viewloader/example/TestJavaViewNoNode.java
@@ -1,0 +1,6 @@
+package de.saxsys.jfx.mvvm.viewloader.example;
+
+import de.saxsys.jfx.mvvm.api.JavaView;
+
+public class TestJavaViewNoNode implements JavaView<TestViewModel> {
+}


### PR DESCRIPTION
...ay it is now possible to load views that derive from Node and not from Parent. Additionally when the user attempts to load a JavaView that isn't derived from Node he gets a useful exeption.
