### PR TITLE
#109 viewmodels are now created even if they aren't referenced in the vi...

### DIFF
--- a/mvvmfx/src/main/java/de/saxsys/jfx/mvvm/viewloader/FxmlViewLoader.java
+++ b/mvvmfx/src/main/java/de/saxsys/jfx/mvvm/viewloader/FxmlViewLoader.java
@@ -18,7 +18,6 @@ package de.saxsys.jfx.mvvm.viewloader;
 import java.io.IOException;
 import java.net.URL;
 import java.util.ResourceBundle;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Parent;
@@ -53,7 +52,6 @@ class FxmlViewLoader {
 	/**
 	 * Load the viewTuple by the path of the fxml file.
 	 */
-	@SuppressWarnings("unchecked")
 	<ViewType extends View<? extends ViewModelType>, ViewModelType extends ViewModel> ViewTuple<ViewType, ViewModelType> loadFxmlViewTuple(
 			final String resource, ResourceBundle resourceBundle, final Object controller, final Object root, ViewModelType viewModel) {
 		try {
@@ -69,9 +67,15 @@ class FxmlViewLoader {
 				throw new IOException("Could not load the controller for the View " + resource
 						+ " maybe your missed the fx:controller in your fxml?");
 			}
+
+
+			ViewModelType loadedViewModel = ReflectionUtils.getViewModel(loadedController);
 			
-			
-			return new ViewTuple<>(loadedController, loadedRoot, ReflectionUtils.getViewModel(loadedController));
+			if(loadedViewModel == null){
+				loadedViewModel = ReflectionUtils.createViewModel(loadedController);
+			}
+
+			return new ViewTuple<>(loadedController, loadedRoot, loadedViewModel);
 			
 		} catch (final IOException ex) {
 			throw new RuntimeException(ex);
@@ -108,7 +112,7 @@ class FxmlViewLoader {
 			if (controller instanceof View) {
 				View view = (View) controller;
 				if(viewModel == null){
-					ReflectionUtils.injectViewModel(view, ReflectionUtils.createViewModel(view.getClass()));
+					ReflectionUtils.injectViewModel(view, ReflectionUtils.createViewModel(view));
 				}else{
 					ReflectionUtils.injectViewModel(view, viewModel);
 				}
@@ -131,7 +135,7 @@ class FxmlViewLoader {
 			if(controller instanceof View){
 				View view = (View) controller;
 
-				ReflectionUtils.injectViewModel(view, ReflectionUtils.createViewModel(view.getClass()));
+				ReflectionUtils.injectViewModel(view, ReflectionUtils.createViewModel(view));
 			}
 
 			return controller;
@@ -176,7 +180,7 @@ class FxmlViewLoader {
 					return view;
 				}
 				
-				ReflectionUtils.injectViewModel(view, ReflectionUtils.createViewModel(view.getClass()));
+				ReflectionUtils.injectViewModel(view, ReflectionUtils.createViewModel(view));
 			}
 
 			return controller;

--- a/mvvmfx/src/main/java/de/saxsys/jfx/mvvm/viewloader/JavaViewLoader.java
+++ b/mvvmfx/src/main/java/de/saxsys/jfx/mvvm/viewloader/JavaViewLoader.java
@@ -64,7 +64,6 @@ class JavaViewLoader {
 	 *
 	 * @return a fully loaded and initialized instance of the view.
 	 */
-	@SuppressWarnings("unchecked")
 	<ViewType extends View<? extends ViewModelType>, ViewModelType extends ViewModel> ViewTuple<ViewType, ViewModelType> loadJavaViewTuple(
 			Class<? extends ViewType>
 			viewType, ResourceBundle resourceBundle, ViewModelType viewModel) {
@@ -78,7 +77,7 @@ class JavaViewLoader {
 		}
 
 		if(viewModel == null){
-			viewModel = (ViewModelType)ReflectionUtils.createViewModel(viewType);
+			viewModel = ReflectionUtils.createViewModel(view);
 		}
 
 		ReflectionUtils.injectViewModel(view, viewModel);

--- a/mvvmfx/src/main/java/de/saxsys/jfx/mvvm/viewloader/ReflectionUtils.java
+++ b/mvvmfx/src/main/java/de/saxsys/jfx/mvvm/viewloader/ReflectionUtils.java
@@ -125,18 +125,22 @@ public class ReflectionUtils {
 
 	}
 
+
 	/**
-	 * Creates a viewModel instance for the given View type. The type of the viewModel is resolved from
-	 * the generic type of the view. 
-	 * 
+	 * Creates a viewModel instance for a View type. The type of the view is determined by the given view instance. 
+	 *
 	 * For the creation of the viewModel the {@link de.saxsys.jfx.mvvm.viewloader.DependencyInjector} is used.
-	 * @param viewType the type of the view.
+
+	 * @param view the view instance that is used to find out the type of the ViewModel 
+	 * @param <ViewType> the generic view type
+	 * @param <ViewModelType> the generic viewModel type
 	 * @return the viewModel instance or <code>null</code> if the viewModel type can't be found or the viewModel can't be created.
 	 */
-	static ViewModel createViewModel(final Class<? extends View> viewType){
-		final Class<?> viewModelType = TypeResolver.resolveRawArgument(View.class, viewType);
-	
-		// This means that the view type has no ViewModel type defined and only the interface type "ViewModel" can be found as type.
+	@SuppressWarnings("unchecked")
+	static <ViewType extends View<? extends ViewModelType>, ViewModelType extends ViewModel> ViewModelType createViewModel(
+			ViewType view){
+		final Class<?> viewModelType = TypeResolver.resolveRawArgument(View.class, view.getClass());
+
 		if(viewModelType == ViewModel.class){
 			return null;
 		}
@@ -145,6 +149,6 @@ public class ReflectionUtils {
 			return null;
 		}
 		
-		return (ViewModel)DependencyInjector.getInstance().getInstanceOf(viewModelType);
+		return (ViewModelType)DependencyInjector.getInstance().getInstanceOf(viewModelType);
 	}
 }

--- a/mvvmfx/src/test/java/de/saxsys/jfx/mvvm/viewloader/ReflectionUtilsTest.java
+++ b/mvvmfx/src/test/java/de/saxsys/jfx/mvvm/viewloader/ReflectionUtilsTest.java
@@ -16,7 +16,7 @@ public class ReflectionUtilsTest {
 		class TestView implements View<TestViewModel> {
 		}
 
-		ViewModel viewModel = ReflectionUtils.createViewModel(TestView.class);
+		ViewModel viewModel = ReflectionUtils.createViewModel(new TestView());
 		
 		assertThat(viewModel).isNotNull().isInstanceOf(TestViewModel.class);
 	}
@@ -26,7 +26,7 @@ public class ReflectionUtilsTest {
 		class TestView implements View{
 		}
 
-		ViewModel viewModel = ReflectionUtils.createViewModel(TestView.class);
+		ViewModel viewModel = ReflectionUtils.createViewModel(new TestView());
 		
 		assertThat(viewModel).isNull();
 	}
@@ -36,7 +36,7 @@ public class ReflectionUtilsTest {
 		class TestView implements View<ViewModel>{
 		}
 		
-		ViewModel viewModel = ReflectionUtils.createViewModel(TestView.class);
+		ViewModel viewModel = ReflectionUtils.createViewModel(new TestView());
 		
 		assertThat(viewModel).isNull();
 	}

--- a/mvvmfx/src/test/java/de/saxsys/jfx/mvvm/viewloader/ViewLoader_FxmlView_Test.java
+++ b/mvvmfx/src/test/java/de/saxsys/jfx/mvvm/viewloader/ViewLoader_FxmlView_Test.java
@@ -21,13 +21,6 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.util.PropertyResourceBundle;
 import java.util.ResourceBundle;
-
-import de.saxsys.jfx.mvvm.testingutils.TestUtils;
-import de.saxsys.jfx.mvvm.viewloader.example.InvalidFxmlTestView;
-import de.saxsys.jfx.mvvm.viewloader.example.TestFxmlViewMultipleViewModels;
-import de.saxsys.jfx.mvvm.viewloader.example.TestViewA;
-import de.saxsys.jfx.mvvm.viewloader.example.TestViewB;
-import de.saxsys.jfx.mvvm.viewloader.example.TestViewModelA;
 import javafx.fxml.LoadException;
 import javafx.scene.layout.VBox;
 
@@ -36,13 +29,20 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import de.saxsys.javafx.test.JfxRunner;
+import de.saxsys.jfx.mvvm.testingutils.TestUtils;
+import de.saxsys.jfx.mvvm.viewloader.example.InvalidFxmlTestView;
 import de.saxsys.jfx.mvvm.viewloader.example.TestFxmlView;
 import de.saxsys.jfx.mvvm.viewloader.example.TestFxmlViewFxRoot;
+import de.saxsys.jfx.mvvm.viewloader.example.TestFxmlViewMultipleViewModels;
 import de.saxsys.jfx.mvvm.viewloader.example.TestFxmlViewWithActionMethod;
 import de.saxsys.jfx.mvvm.viewloader.example.TestFxmlViewWithMissingController;
 import de.saxsys.jfx.mvvm.viewloader.example.TestFxmlViewWithWrongController;
-import de.saxsys.jfx.mvvm.viewloader.example.TestFxmlViewWithoutViewModel;
+import de.saxsys.jfx.mvvm.viewloader.example.TestFxmlViewWithoutViewModelField;
+import de.saxsys.jfx.mvvm.viewloader.example.TestFxmlViewWithoutViewModelType;
+import de.saxsys.jfx.mvvm.viewloader.example.TestViewA;
+import de.saxsys.jfx.mvvm.viewloader.example.TestViewB;
 import de.saxsys.jfx.mvvm.viewloader.example.TestViewModel;
+import de.saxsys.jfx.mvvm.viewloader.example.TestViewModelA;
 
 /**
  * Test the loading of FxmlViews.
@@ -78,16 +78,16 @@ public class ViewLoader_FxmlView_Test {
 	}
 	
 	@Test
-	public void testViewWithoutViewModel() {
+	public void testViewWithoutViewModelType() {
 		
-		final ViewTuple viewTuple = FluentViewLoader.fxmlView(TestFxmlViewWithoutViewModel.class).load();
+		final ViewTuple viewTuple = FluentViewLoader.fxmlView(TestFxmlViewWithoutViewModelType.class).load();
 		
 		assertThat(viewTuple).isNotNull();
 		
 		assertThat(viewTuple.getView()).isNotNull().isInstanceOf(VBox.class);
-		assertThat(viewTuple.getCodeBehind()).isNotNull().isInstanceOf(TestFxmlViewWithoutViewModel.class);
+		assertThat(viewTuple.getCodeBehind()).isNotNull().isInstanceOf(TestFxmlViewWithoutViewModelType.class);
 		
-		final TestFxmlViewWithoutViewModel codeBehind = (TestFxmlViewWithoutViewModel) viewTuple.getCodeBehind();
+		final TestFxmlViewWithoutViewModelType codeBehind = (TestFxmlViewWithoutViewModelType) viewTuple.getCodeBehind();
 		
 		assertThat(codeBehind.wasInitialized).isTrue();
 		assertThat(codeBehind.viewModel).isNull();
@@ -202,8 +202,7 @@ public class ViewLoader_FxmlView_Test {
 
 		codeBehind.viewModel = existingViewModel;
 
-		ViewTuple<TestFxmlViewWithMissingController, TestViewModel> viewTuple = FluentViewLoader.fxmlView(
-				TestFxmlViewWithMissingController.class).codeBehind(codeBehind).load();
+		ViewTuple<TestFxmlViewWithMissingController, TestViewModel> viewTuple = FluentViewLoader.fxmlView(TestFxmlViewWithMissingController.class).codeBehind(codeBehind).load();
 
 		assertThat(viewTuple.getCodeBehind()).isNotNull();
 		assertThat(viewTuple.getCodeBehind().viewModel).isEqualTo(existingViewModel);
@@ -289,4 +288,18 @@ public class ViewLoader_FxmlView_Test {
 		assertThat(viewTupleTwo.getCodeBehind()).isNotEqualTo(viewTupleOne.getCodeBehind());
 	}
 
+	/**
+	 * When the ViewModel isn't injected in the view it should still be available in the ViewTuple.
+	 */
+	@Test
+	public void testViewModelIsAvailableInViewTupleEvenIfItIsntInjectedInTheView(){
+
+		ViewTuple<TestFxmlViewWithoutViewModelField, TestViewModel> viewTuple = FluentViewLoader
+				.fxmlView(TestFxmlViewWithoutViewModelField.class).load();
+		
+		assertThat(viewTuple.getCodeBehind().wasInitialized).isTrue();
+		
+		assertThat(viewTuple.getViewModel()).isNotNull();
+
+	}
 }

--- a/mvvmfx/src/test/java/de/saxsys/jfx/mvvm/viewloader/ViewLoader_JavaView_Test.java
+++ b/mvvmfx/src/test/java/de/saxsys/jfx/mvvm/viewloader/ViewLoader_JavaView_Test.java
@@ -198,7 +198,23 @@ public class ViewLoader_JavaView_Test {
 			assertThat(e).isInstanceOf(RuntimeException.class).hasMessageContaining("<2> viewModel fields");
 		}
 	}
-	
+
+
+
+	/**
+	 * When the ViewModel isn't injected in the view it should still be available in the ViewTuple.
+	 */
+	@Test
+	public void testViewModelIsAvailableInViewTupleEvenIfItIsntInjectedInTheView(){
+		
+		class TestView extends VBox implements JavaView<TestViewModel>{
+		}
+
+		ViewTuple<TestView, TestViewModel> viewTuple = FluentViewLoader
+				.javaView(TestView.class).load();
+
+		assertThat(viewTuple.getViewModel()).isNotNull();
+	}
 	
 	
 	@Test

--- a/mvvmfx/src/test/java/de/saxsys/jfx/mvvm/viewloader/example/TestFxmlViewWithoutViewModelField.java
+++ b/mvvmfx/src/test/java/de/saxsys/jfx/mvvm/viewloader/example/TestFxmlViewWithoutViewModelField.java
@@ -1,0 +1,13 @@
+package de.saxsys.jfx.mvvm.viewloader.example;
+
+import de.saxsys.jfx.mvvm.api.FxmlView;
+
+
+public class TestFxmlViewWithoutViewModelField implements FxmlView<TestViewModel> {
+
+	public boolean wasInitialized = false;
+
+	public void initialize() {
+		wasInitialized = true;
+	}
+}

--- a/mvvmfx/src/test/java/de/saxsys/jfx/mvvm/viewloader/example/TestFxmlViewWithoutViewModelType.java
+++ b/mvvmfx/src/test/java/de/saxsys/jfx/mvvm/viewloader/example/TestFxmlViewWithoutViewModelType.java
@@ -7,7 +7,7 @@ import javafx.fxml.Initializable;
 import de.saxsys.jfx.mvvm.api.FxmlView;
 import de.saxsys.jfx.mvvm.api.InjectViewModel;
 
-public class TestFxmlViewWithoutViewModel implements FxmlView, Initializable {
+public class TestFxmlViewWithoutViewModelType implements FxmlView, Initializable {
 	
 	// this injection point will be ignored as this view class doesn't define a ViewModelType
 	@InjectViewModel

--- a/mvvmfx/src/test/resources/de/saxsys/jfx/mvvm/viewloader/example/TestFxmlViewWithoutViewModelField.fxml
+++ b/mvvmfx/src/test/resources/de/saxsys/jfx/mvvm/viewloader/example/TestFxmlViewWithoutViewModelField.fxml
@@ -2,6 +2,6 @@
 
 <?import javafx.scene.layout.VBox?>
 <VBox xmlns:fx="http://javafx.com/fxml"
-	  fx:controller="de.saxsys.jfx.mvvm.viewloader.example.TestFxmlViewWithoutViewModel">
+	  fx:controller="de.saxsys.jfx.mvvm.viewloader.example.TestFxmlViewWithoutViewModelField">
 
 </VBox>

--- a/mvvmfx/src/test/resources/de/saxsys/jfx/mvvm/viewloader/example/TestFxmlViewWithoutViewModelType.fxml
+++ b/mvvmfx/src/test/resources/de/saxsys/jfx/mvvm/viewloader/example/TestFxmlViewWithoutViewModelType.fxml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.layout.VBox?>
+<VBox xmlns:fx="http://javafx.com/fxml"
+	  fx:controller="de.saxsys.jfx.mvvm.viewloader.example.TestFxmlViewWithoutViewModelType">
+
+</VBox>


### PR DESCRIPTION
...ew. In this case the viewModel can still be accessed from the ViewTuple.

Done some Refectoring of the ReflectionUtil and removed some unchecked castings.
