### PR TITLE
#158 add configuration for archetype deployment

### DIFF
--- a/mvvmfx-archetype/README.md
+++ b/mvvmfx-archetype/README.md
@@ -13,5 +13,3 @@ To use this archetype:
         
 
 This creates an example mvvmfx project similar to the [mvvmfx-helloworld example](/examples/mvvmfx-helloworld).
-
-*Hint:* At the moment the archetype isn't available in the central archetype catalogue. This means that you have to `mvn install` the archetype into your local repository to be able to use it.

--- a/mvvmfx-archetype/pom.xml
+++ b/mvvmfx-archetype/pom.xml
@@ -10,6 +10,7 @@
 
 
 	<artifactId>mvvmfx-archetype</artifactId>
+	<packaging>maven-archetype</packaging>
 	<name>mvvmFX Archetype</name>
 	
 	<description>
@@ -22,6 +23,23 @@
 	
 
 	<build>
+		<extensions>
+			<extension>
+				<groupId>org.apache.maven.archetype</groupId>
+				<artifactId>archetype-packaging</artifactId>
+				<version>2.2</version>
+			</extension>
+		</extensions>
+
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-archetype-plugin</artifactId>
+					<version>2.2</version>
+				</plugin>
+			</plugins>
+		</pluginManagement>
 		<plugins>
 			<plugin>
 				<artifactId>maven-resources-plugin</artifactId>


### PR DESCRIPTION
according to http://maven.apache.org/archetype/archetype-packaging/
the packaging of the maven module has to be 'maven-archetype'. Additionally some plugin configuration is needed. I hope that his is sufficient to get the archetype into the central archetype catalog
