### PR TITLE
notRunningProperty and notExecuteableProperty in Commands

### DIFF
--- a/examples/mvvmfx-complex-example/src/main/java/de/saxsys/jfx/exampleapplication/view/personlogin/PersonLoginView.java
+++ b/examples/mvvmfx-complex-example/src/main/java/de/saxsys/jfx/exampleapplication/view/personlogin/PersonLoginView.java
@@ -43,7 +43,7 @@ public class PersonLoginView implements FxmlView<PersonLoginViewModel>, Initiali
 		loginCommand = getViewModel().getLoginCommand();
 		initChoiceBox();
 		loginButton.disableProperty()
-				.bind(loginCommand.executableProperty().not());
+				.bind(loginCommand.notExecutableProperty());
 		loginProgressIndicator.visibleProperty().bind(loginCommand.runningProperty());
 	}
 	

--- a/mvvmfx/src/main/java/de/saxsys/mvvmfx/utils/commands/Command.java
+++ b/mvvmfx/src/main/java/de/saxsys/mvvmfx/utils/commands/Command.java
@@ -15,8 +15,8 @@
  ******************************************************************************/
 package de.saxsys.mvvmfx.utils.commands;
 
-import eu.lestard.doc.Beta;
 import javafx.beans.property.ReadOnlyBooleanProperty;
+import eu.lestard.doc.Beta;
 
 /**
  * The {@link Command} encapsulates logic in the {@link #execute()} method which will be called later. This can be used
@@ -50,6 +50,18 @@ public interface Command {
 	 */
 	ReadOnlyBooleanProperty executableProperty();
 	
+	/**
+	 * Determines whether the command can not execute in it's current state.
+	 * 
+	 * @return <code>true</code> if the {@link Command} can not execute, otherwise <code>false</code>.
+	 */
+	boolean isNotExecutable();
+	
+	/**
+	 * @see #isNotExecutable()
+	 */
+	ReadOnlyBooleanProperty notExecutableProperty();
+	
 	
 	/**
 	 * Signals whether the command is currently executing. This can be useful especially for commands that are executed
@@ -63,5 +75,20 @@ public interface Command {
 	 * @see #isRunning()
 	 */
 	ReadOnlyBooleanProperty runningProperty();
+	
+	/**
+	 * Signals whether the command is currently not executing. This can be useful especially for commands that are
+	 * executed asynchronously.
+	 * 
+	 * @return <code>true</code> if the {@link Command} is not running, otherwise <code>false</code>.
+	 */
+	boolean isNotRunning();
+	
+	/**
+	 * @see #isNotRunning()
+	 */
+	ReadOnlyBooleanProperty notRunningProperty();
+	
+	
 	
 }

--- a/mvvmfx/src/main/java/de/saxsys/mvvmfx/utils/commands/CommandBase.java
+++ b/mvvmfx/src/main/java/de/saxsys/mvvmfx/utils/commands/CommandBase.java
@@ -32,24 +32,55 @@ public abstract class CommandBase implements Command {
 	protected final ReadOnlyBooleanWrapper executable = new ReadOnlyBooleanWrapper(true);
 	protected final ReadOnlyBooleanWrapper running = new ReadOnlyBooleanWrapper(false);
 	
+	protected ReadOnlyBooleanWrapper notExecutable;
+	protected ReadOnlyBooleanWrapper notRunning;
+	
 	@Override
-	public ReadOnlyBooleanProperty executableProperty() {
-		return this.executable.getReadOnlyProperty();
+	public final ReadOnlyBooleanProperty executableProperty() {
+		return executable.getReadOnlyProperty();
 	}
 	
 	@Override
-	public boolean isExecutable() {
-		return this.executableProperty().get();
+	public final boolean isExecutable() {
+		return executableProperty().get();
 	}
 	
 	@Override
-	public ReadOnlyBooleanProperty runningProperty() {
-		return this.running.getReadOnlyProperty();
+	public final ReadOnlyBooleanProperty notExecutableProperty() {
+		if (notExecutable == null) {
+			notExecutable = new ReadOnlyBooleanWrapper();
+			notExecutable.bind(executableProperty().not());
+		}
+		return notExecutable.getReadOnlyProperty();
 	}
 	
 	@Override
-	public boolean isRunning() {
-		return this.running.get();
+	public final boolean isNotExecutable() {
+		return notExecutableProperty().get();
+	}
+	
+	@Override
+	public final ReadOnlyBooleanProperty runningProperty() {
+		return running.getReadOnlyProperty();
+	}
+	
+	@Override
+	public final boolean isRunning() {
+		return running.get();
+	}
+	
+	@Override
+	public final ReadOnlyBooleanProperty notRunningProperty() {
+		if (notRunning == null) {
+			notRunning = new ReadOnlyBooleanWrapper();
+			notRunning.bind(runningProperty().not());
+		}
+		return notRunning.getReadOnlyProperty();
+	}
+	
+	@Override
+	public final boolean isNotRunning() {
+		return notRunningProperty().get();
 	}
 	
 	@Override

--- a/mvvmfx/src/test/java/de/saxsys/mvvmfx/utils/commands/DelegateCommandTest.java
+++ b/mvvmfx/src/test/java/de/saxsys/mvvmfx/utils/commands/DelegateCommandTest.java
@@ -23,14 +23,17 @@ public class DelegateCommandTest {
 		}, condition);
 		
 		assertTrue(delegateCommand.isExecutable());
+		assertFalse(delegateCommand.isNotExecutable());
 		
 		condition.set(false);
 		
 		assertFalse(delegateCommand.isExecutable());
+		assertTrue(delegateCommand.isNotExecutable());
 		
 		condition.set(true);
 		
 		assertTrue(delegateCommand.isExecutable());
+		assertFalse(delegateCommand.isNotExecutable());
 	}
 	
 	@Test
@@ -69,9 +72,11 @@ public class DelegateCommandTest {
 		delegateCommand.runningProperty().addListener((ChangeListener<Boolean>) (observable, oldValue, newValue) -> {
 			if (!oldValue && newValue) {
 				run.set(true);
+				assertFalse(delegateCommand.notRunningProperty().get());
 			}
 			if (oldValue && !newValue) {
 				finished.set(true);
+				assertTrue(delegateCommand.notRunningProperty().get());
 			}
 		});
 		
@@ -97,12 +102,19 @@ public class DelegateCommandTest {
 		}, condition, true);
 		
 		assertFalse(delegateCommand.runningProperty().get());
+		assertTrue(delegateCommand.notRunningProperty().get());
 		delegateCommand.execute();
+		
 		assertTrue(delegateCommand.runningProperty().get());
+		assertFalse(delegateCommand.notRunningProperty().get());
 		assertFalse(delegateCommand.executableProperty().get());
+		assertTrue(delegateCommand.notExecutableProperty().get());
+		
 		future.get(3, TimeUnit.SECONDS);
 		assertFalse(delegateCommand.runningProperty().get());
+		assertTrue(delegateCommand.notRunningProperty().get());
 		assertTrue(delegateCommand.executableProperty().get());
+		assertFalse(delegateCommand.notExecutableProperty().get());
 	}
 	
 }


### PR DESCRIPTION
I created following things in the Commands Interface:
-- Negated Property for .runningProperty() -> .notRunningProperty()
-- Negated Property for .executableProperty() -> .not executableProperty()

-Made running / executable getters / setters in CommandBase final
-Modified Example

https://github.com/sialcasa/mvvmFX/issues/210
