### PR TITLE
Use Maven's managed dependencies

### DIFF
--- a/examples/mvvmfx-books-example/pom.xml
+++ b/examples/mvvmfx-books-example/pom.xml
@@ -21,7 +21,6 @@
 		<dependency>
 			<groupId>de.saxsys</groupId>
 			<artifactId>mvvmfx</artifactId>
-			<version>${project.parent.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>eu.lestard</groupId>

--- a/examples/mvvmfx-cdi-starter/pom.xml
+++ b/examples/mvvmfx-cdi-starter/pom.xml
@@ -31,17 +31,14 @@
 		<dependency>
 			<groupId>de.saxsys</groupId>
 			<artifactId>mvvmfx</artifactId>
-			<version>${project.parent.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>de.saxsys</groupId>
 			<artifactId>mvvmfx-cdi</artifactId>
-			<version>${project.parent.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>de.saxsys</groupId>
 			<artifactId>mvvmfx-complex</artifactId>
-			<version>${project.parent.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jboss</groupId>

--- a/examples/mvvmfx-complex-example/pom.xml
+++ b/examples/mvvmfx-complex-example/pom.xml
@@ -45,7 +45,6 @@
 		<dependency>
 			<groupId>de.saxsys</groupId>
 			<artifactId>mvvmfx</artifactId>
-			<version>${project.parent.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.guava</groupId>

--- a/examples/mvvmfx-contacts/pom.xml
+++ b/examples/mvvmfx-contacts/pom.xml
@@ -33,12 +33,10 @@
 		<dependency>
 			<groupId>de.saxsys</groupId>
 			<artifactId>mvvmfx</artifactId>
-			<version>${project.parent.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>de.saxsys</groupId>
 			<artifactId>mvvmfx-cdi</artifactId>
-			<version>${project.parent.version}</version>
 		</dependency>
 
 		<dependency>
@@ -117,7 +115,6 @@
         <dependency>
             <groupId>de.saxsys</groupId>
             <artifactId>mvvmfx-testing-utils</artifactId>
-            <version>${project.parent.version}</version>
             <scope>test</scope>
         </dependency>
 	</dependencies>

--- a/examples/mvvmfx-fx-root-example/pom.xml
+++ b/examples/mvvmfx-fx-root-example/pom.xml
@@ -21,7 +21,6 @@
 		<dependency>
 			<groupId>de.saxsys</groupId>
 			<artifactId>mvvmfx</artifactId>
-			<version>${project.parent.version}</version>
 		</dependency>
 
 		<dependency>

--- a/examples/mvvmfx-guice-starter/pom.xml
+++ b/examples/mvvmfx-guice-starter/pom.xml
@@ -45,17 +45,14 @@
 		<dependency>
 			<groupId>de.saxsys</groupId>
 			<artifactId>mvvmfx</artifactId>
-			<version>${project.parent.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>de.saxsys</groupId>
 			<artifactId>mvvmfx-guice</artifactId>
-			<version>${project.parent.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>de.saxsys</groupId>
 			<artifactId>mvvmfx-complex</artifactId>
-			<version>${project.parent.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>

--- a/examples/mvvmfx-helloworld-without-fxml/pom.xml
+++ b/examples/mvvmfx-helloworld-without-fxml/pom.xml
@@ -21,7 +21,6 @@
 		<dependency>
 			<groupId>de.saxsys</groupId>
 			<artifactId>mvvmfx</artifactId>
-			<version>${project.parent.version}</version>
 		</dependency>
 	</dependencies>
 

--- a/examples/mvvmfx-helloworld/pom.xml
+++ b/examples/mvvmfx-helloworld/pom.xml
@@ -19,7 +19,6 @@
 		<dependency>
 			<groupId>de.saxsys</groupId>
 			<artifactId>mvvmfx</artifactId>
-			<version>${project.parent.version}</version>
 		</dependency>
 	</dependencies>
 

--- a/examples/mvvmfx-synchronizefx/pom.xml
+++ b/examples/mvvmfx-synchronizefx/pom.xml
@@ -19,7 +19,6 @@
 		<dependency>
 			<groupId>de.saxsys</groupId>
 			<artifactId>mvvmfx</artifactId>
-			<version>${project.parent.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>de.saxsys.synchronizefx</groupId>

--- a/examples/mvvmfx-todomvc/pom.xml
+++ b/examples/mvvmfx-todomvc/pom.xml
@@ -15,7 +15,6 @@
 		<dependency>
 			<groupId>de.saxsys</groupId>
 			<artifactId>mvvmfx</artifactId>
-			<version>${project.parent.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.fxmisc.easybind</groupId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -25,4 +25,60 @@
 		<module>mvvmfx-todomvc</module>
 	</modules>
 
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>de.saxsys</groupId>
+				<artifactId>mvvmfx-complex</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>de.saxsys</groupId>
+				<artifactId>mvvmfx-guice-example</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>de.saxsys</groupId>
+				<artifactId>mvvmfx-cdi-example</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>de.saxsys</groupId>
+				<artifactId>mvvmfx-fx-root-example</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>de.saxsys</groupId>
+				<artifactId>mvvmfx-helloworld</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>de.saxsys</groupId>
+				<artifactId>mvvmfx-helloworld-without-fxml</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>de.saxsys</groupId>
+				<artifactId>mvvmfx-synchronizefx</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>de.saxsys</groupId>
+				<artifactId>mvvmfx-contacts</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>de.saxsys</groupId>
+				<artifactId>mvvmfx-library-example</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>de.saxsys</groupId>
+				<artifactId>mvvmfx-todomvc</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
 </project>

--- a/mvvmfx-archetype/pom.xml
+++ b/mvvmfx-archetype/pom.xml
@@ -17,10 +17,6 @@
 		An maven archetype to create an example application with mvvmFX
 	</description>
 
-	<properties>
-		<version.mvvmfx>${project.parent.version}</version.mvvmfx>
-	</properties>
-
 
 	<build>
 		<extensions>

--- a/mvvmfx-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/mvvmfx-archetype/src/main/resources/archetype-resources/pom.xml
@@ -11,12 +11,22 @@
 		<maven.compiler.target>1.8</maven.compiler.target>
 	</properties>
 
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>de.saxsys</groupId>
+				<artifactId>mvvmfx-parent</artifactId>
+				<version>1.4.0-SNAPSHOT</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 
 	<dependencies>
 		<dependency>
 			<groupId>de.saxsys</groupId>
 			<artifactId>mvvmfx</artifactId>
-			<version>${version}</version>
 		</dependency>
 	</dependencies>
 

--- a/mvvmfx-cdi/pom.xml
+++ b/mvvmfx-cdi/pom.xml
@@ -49,7 +49,6 @@
 		<dependency>
 			<groupId>de.saxsys</groupId>
 			<artifactId>mvvmfx</artifactId>
-			<version>${project.parent.version}</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/mvvmfx-guice/pom.xml
+++ b/mvvmfx-guice/pom.xml
@@ -46,7 +46,6 @@
 		<dependency>
 			<groupId>de.saxsys</groupId>
 			<artifactId>mvvmfx</artifactId>
-			<version>${project.parent.version}</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/mvvmfx-utils/pom.xml
+++ b/mvvmfx-utils/pom.xml
@@ -19,7 +19,6 @@
         <dependency>
             <groupId>de.saxsys</groupId>
             <artifactId>mvvmfx-testing-utils</artifactId>
-            <version>${project.parent.version}</version>
         </dependency>
 
 

--- a/mvvmfx/pom.xml
+++ b/mvvmfx/pom.xml
@@ -56,7 +56,6 @@
 		<dependency>
 			<groupId>de.saxsys</groupId>
 			<artifactId>mvvmfx-testing-utils</artifactId>
-			<version>${project.parent.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,38 @@
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
+				<groupId>de.saxsys</groupId>
+				<artifactId>mvvmfx</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>de.saxsys</groupId>
+				<artifactId>mvvmfx-cdi</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>de.saxsys</groupId>
+				<artifactId>mvvmfx-guice</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>de.saxsys</groupId>
+				<artifactId>mvvmfx-archetype</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>de.saxsys</groupId>
+				<artifactId>mvvmfx-utils</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>de.saxsys</groupId>
+				<artifactId>mvvmfx-testing-utils</artifactId>
+				<version>${project.version}</version>
+				<scope>test</scope>
+			</dependency>
+
+			<dependency>
 				<groupId>org.slf4j</groupId>
 				<artifactId>slf4j-api</artifactId>
 				<version>1.7.12</version>


### PR DESCRIPTION
Declaring the `mvvmfx-*` artifacts in `mvvmfx-parent`'s managed dependencies gives users a centralised version management for all `mvvmfx-parent` descendants. It's extensively explained in [Maven docs](https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Dependency_Management).

But simply speaking, it puts the required version of all `mvvmfx-*` artifacts in one place. Users now can declare dependencies:

```
<dependencyManagement>
    <dependencies>
        <dependency>
            <groupId>de.saxsys</groupId>
            <artifactId>mvvmfx-parent</artifactId>
            <version>1.4.0-SNAPSHOT</version>
            <type>pom</type>
            <scope>import</scope>
        </dependency>
    </dependencies>
</dependencyManagement>

<dependencies>
    <dependency>
        <groupId>de.saxsys</groupId>
        <artifactId>mvvmfx</artifactId>
    </dependency>
    <dependency>
        <groupId>de.saxsys</groupId>
        <artifactId>mvvmfx-cdi</artifactId>
    </dependency>
    ...
</dependencies>
```

Although all other `mvvmfx-*` artifacts are listed in `<managedDependencies>` only the ones specifically listed in `<dependencies>` are actually used.

There is one drawback to this. The `<scope>import</scope>` attribute is only available in Maven 2.0.9 or later.
