### PR TITLE
335 guice aop

### DIFF
--- a/mvvmfx-guice/src/test/java/de/saxsys/mvvmfx/guice/interceptiontest/InterceptedView.java
+++ b/mvvmfx-guice/src/test/java/de/saxsys/mvvmfx/guice/interceptiontest/InterceptedView.java
@@ -10,7 +10,6 @@ public class InterceptedView implements FxmlView<InterceptedViewModel> {
     @InjectViewModel
     private InterceptedViewModel viewModel;
 
-
     public void initialize() {
         wasInitCalled = true;
         vmWasInjected = viewModel != null;

--- a/mvvmfx-guice/src/test/java/de/saxsys/mvvmfx/guice/interceptiontest/InterceptedView.java
+++ b/mvvmfx-guice/src/test/java/de/saxsys/mvvmfx/guice/interceptiontest/InterceptedView.java
@@ -10,12 +10,8 @@ public class InterceptedView implements FxmlView<InterceptedViewModel> {
     @InjectViewModel
     private InterceptedViewModel viewModel;
 
-    public InterceptedView() {
-        System.out.println("new InterceptedView()");
-    }
 
     public void initialize() {
-        System.out.println("init");
         wasInitCalled = true;
         vmWasInjected = viewModel != null;
     }

--- a/mvvmfx-guice/src/test/java/de/saxsys/mvvmfx/guice/interceptiontest/InterceptedView.java
+++ b/mvvmfx-guice/src/test/java/de/saxsys/mvvmfx/guice/interceptiontest/InterceptedView.java
@@ -1,0 +1,23 @@
+package de.saxsys.mvvmfx.guice.interceptiontest;
+
+import de.saxsys.mvvmfx.FxmlView;
+import de.saxsys.mvvmfx.InjectViewModel;
+
+public class InterceptedView implements FxmlView<InterceptedViewModel> {
+    public static boolean vmWasInjected = false;
+    public static boolean wasInitCalled = false;
+
+    @InjectViewModel
+    private InterceptedViewModel viewModel;
+
+    public InterceptedView() {
+        System.out.println("new InterceptedView()");
+    }
+
+    public void initialize() {
+        System.out.println("init");
+        wasInitCalled = true;
+        vmWasInjected = viewModel != null;
+    }
+
+}

--- a/mvvmfx-guice/src/test/java/de/saxsys/mvvmfx/guice/interceptiontest/InterceptedViewModel.java
+++ b/mvvmfx-guice/src/test/java/de/saxsys/mvvmfx/guice/interceptiontest/InterceptedViewModel.java
@@ -1,0 +1,9 @@
+package de.saxsys.mvvmfx.guice.interceptiontest;
+
+import de.saxsys.mvvmfx.ViewModel;
+
+public class InterceptedViewModel implements ViewModel {
+
+
+
+}

--- a/mvvmfx-guice/src/test/java/de/saxsys/mvvmfx/guice/interceptiontest/InterceptorModule.java
+++ b/mvvmfx-guice/src/test/java/de/saxsys/mvvmfx/guice/interceptiontest/InterceptorModule.java
@@ -1,0 +1,12 @@
+package de.saxsys.mvvmfx.guice.interceptiontest;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.matcher.Matchers;
+
+public class InterceptorModule implements Module {
+    @Override
+    public void configure(Binder binder) {
+        binder.bindInterceptor(Matchers.subclassesOf(InterceptedView.class), Matchers.any(), new TestInterceptor());
+    }
+}

--- a/mvvmfx-guice/src/test/java/de/saxsys/mvvmfx/guice/interceptiontest/InterceptorTest.java
+++ b/mvvmfx-guice/src/test/java/de/saxsys/mvvmfx/guice/interceptiontest/InterceptorTest.java
@@ -1,7 +1,6 @@
 package de.saxsys.mvvmfx.guice.interceptiontest;
 
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -13,7 +12,7 @@ public class InterceptorTest {
 
 
     @Test
-    @Ignore("until fixed")
+//    @Ignore("until fixed")
     public void test() {
 
         InterceptedView.vmWasInjected = false;
@@ -22,6 +21,9 @@ public class InterceptorTest {
 
 
         InterceptorTestApp.main();
+
+        final InterceptedView codeBehind = InterceptorTestApp.viewTuple.getCodeBehind();
+
 
         assertThat(TestInterceptor.wasIntercepted).isTrue();
 

--- a/mvvmfx-guice/src/test/java/de/saxsys/mvvmfx/guice/interceptiontest/InterceptorTest.java
+++ b/mvvmfx-guice/src/test/java/de/saxsys/mvvmfx/guice/interceptiontest/InterceptorTest.java
@@ -1,0 +1,33 @@
+package de.saxsys.mvvmfx.guice.interceptiontest;
+
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test case to check AOP features (Interceptors) of Guice with mvvmFX.
+ */
+public class InterceptorTest {
+
+
+    @Test
+    @Ignore("until fixed")
+    public void test() {
+
+        InterceptedView.vmWasInjected = false;
+        InterceptedView.wasInitCalled = false;
+        TestInterceptor.wasIntercepted = false;
+
+
+        InterceptorTestApp.main();
+
+        assertThat(TestInterceptor.wasIntercepted).isTrue();
+
+
+        assertThat(InterceptedView.wasInitCalled).isTrue();
+        assertThat(InterceptedView.vmWasInjected).isTrue();
+    }
+
+}

--- a/mvvmfx-guice/src/test/java/de/saxsys/mvvmfx/guice/interceptiontest/InterceptorTestApp.java
+++ b/mvvmfx-guice/src/test/java/de/saxsys/mvvmfx/guice/interceptiontest/InterceptorTestApp.java
@@ -1,0 +1,36 @@
+package de.saxsys.mvvmfx.guice.interceptiontest;
+
+import com.google.inject.Module;
+import de.saxsys.mvvmfx.FluentViewLoader;
+import de.saxsys.mvvmfx.ViewTuple;
+import de.saxsys.mvvmfx.guice.MvvmfxGuiceApplication;
+import javafx.application.Platform;
+import javafx.stage.Stage;
+
+import java.util.List;
+
+public class InterceptorTestApp extends MvvmfxGuiceApplication {
+
+    public static ViewTuple<InterceptedView, InterceptedViewModel> viewTuple;
+
+
+    public static void main(String... args) {
+        launch(args);
+    }
+
+
+    @Override
+    public void startMvvmfx(Stage stage) throws Exception {
+
+        viewTuple = FluentViewLoader.fxmlView(InterceptedView.class).load();
+
+        // we can't shutdown the application in the test case so we need to do it here.
+        Platform.exit();
+    }
+
+
+    @Override
+    public void initGuiceModules(List<Module> modules) throws Exception {
+        modules.add(new InterceptorModule());
+    }
+}

--- a/mvvmfx-guice/src/test/java/de/saxsys/mvvmfx/guice/interceptiontest/TestInterceptor.java
+++ b/mvvmfx-guice/src/test/java/de/saxsys/mvvmfx/guice/interceptiontest/TestInterceptor.java
@@ -1,0 +1,15 @@
+package de.saxsys.mvvmfx.guice.interceptiontest;
+
+import org.aopalliance.intercept.MethodInterceptor;
+import org.aopalliance.intercept.MethodInvocation;
+
+public class TestInterceptor implements MethodInterceptor {
+    public static boolean wasIntercepted = false;
+
+    @Override
+    public Object invoke(MethodInvocation methodInvocation) throws Throwable {
+        wasIntercepted = true;
+
+        return methodInvocation.proceed();
+    }
+}

--- a/mvvmfx-guice/src/test/java/de/saxsys/mvvmfx/guice/it/IntegrationTest.java
+++ b/mvvmfx-guice/src/test/java/de/saxsys/mvvmfx/guice/it/IntegrationTest.java
@@ -1,11 +1,10 @@
 package de.saxsys.mvvmfx.guice.it;
 
-import static org.assertj.core.api.Assertions.*;
-
+import de.saxsys.mvvmfx.guice.internal.GuiceInjector;
 import org.junit.Before;
 import org.junit.Test;
 
-import de.saxsys.mvvmfx.guice.internal.GuiceInjector;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class IntegrationTest {
 	
@@ -15,6 +14,7 @@ public class IntegrationTest {
 		MyApp.wasStopCalled = false;
 		MyModule.works = false;
 		MyViewModel.works = false;
+        MyView.wasInitCalled = false;
 	}
 	
 	@Test
@@ -48,6 +48,8 @@ public class IntegrationTest {
 		
 		assertThat(MyModule.works).isTrue();
 		assertThat(MyViewModel.works).isTrue();
+
+        assertThat(MyView.wasInitCalled).isTrue();
 		
 	}
 	

--- a/mvvmfx-guice/src/test/java/de/saxsys/mvvmfx/guice/it/MyView.java
+++ b/mvvmfx-guice/src/test/java/de/saxsys/mvvmfx/guice/it/MyView.java
@@ -1,13 +1,12 @@
 package de.saxsys.mvvmfx.guice.it;
 
+import de.saxsys.mvvmfx.FxmlView;
 import de.saxsys.mvvmfx.utils.notifications.NotificationCenter;
 import javafx.application.Application;
 import javafx.application.HostServices;
 import javafx.stage.Stage;
 
 import javax.inject.Inject;
-
-import de.saxsys.mvvmfx.FxmlView;
 
 public class MyView implements FxmlView<MyViewModel> {
 	@Inject
@@ -21,5 +20,11 @@ public class MyView implements FxmlView<MyViewModel> {
 	
 	@Inject
 	HostServices hostServices;
-	
+
+    public static boolean wasInitCalled = false;
+
+
+    public void initialize() {
+        wasInitCalled = true;
+    }
 }

--- a/mvvmfx-guice/src/test/java/de/saxsys/mvvmfx/guice/it/MyViewModel.java
+++ b/mvvmfx-guice/src/test/java/de/saxsys/mvvmfx/guice/it/MyViewModel.java
@@ -18,6 +18,4 @@ public class MyViewModel implements ViewModel {
 		assertThat(service).isNotNull();
 		works = true;
 	}
-	
-	
 }

--- a/mvvmfx-guice/src/test/resources/de/saxsys/mvvmfx/guice/interceptiontest/InterceptedView.fxml
+++ b/mvvmfx-guice/src/test/resources/de/saxsys/mvvmfx/guice/interceptiontest/InterceptedView.fxml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import java.lang.*?>
+<?import javafx.scene.layout.*?>
+
+
+<AnchorPane fx:controller="de.saxsys.mvvmfx.guice.interceptiontest.InterceptedView" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="400.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/8.0.40" xmlns:fx="http://javafx.com/fxml/1" />

--- a/mvvmfx/src/main/java/de/saxsys/mvvmfx/internal/viewloader/ReflectionUtils.java
+++ b/mvvmfx/src/main/java/de/saxsys/mvvmfx/internal/viewloader/ReflectionUtils.java
@@ -4,6 +4,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -35,10 +36,41 @@ public class ReflectionUtils {
 	 * @return a List of Fields that are annotated with the given annotation.
 	 */
 	public static List<Field> getFieldsWithAnnotation(Object target, Class<? extends Annotation> annotationType) {
-		return Arrays.stream(target.getClass().getDeclaredFields())
+		return ReflectionUtils.getFieldsFromClassHierarchy(target.getClass())
+                .stream()
 				.filter(field -> field.isAnnotationPresent(annotationType))
 				.collect(Collectors.toList());
 	}
+	
+	
+	/**
+	 * Returns all fields of the given type and all parent types (except Object).
+	 * <br>
+	 * The difference to {@link Class#getFields()} is that getFields only returns public fields while this method will
+	 * return all fields whatever the access modifier is.
+	 * <br>
+     *
+	 * The difference to {@link Class#getDeclaredFields()} is that getDeclaredFields returns all fields (with all
+	 * modifiers) from the given class but not from super classes. This method instead will return all fields of all
+	 * modifiers from all super classes up in the class hierarchy, except from Object itself.
+	 *
+	 * @param type the type whose fields will be searched.
+	 * @return a list of field instances.
+	 */
+	public static List<Field> getFieldsFromClassHierarchy(Class<?> type) {
+		
+		final List<Field> classFields = new ArrayList<>();
+		classFields.addAll(Arrays.asList(type.getDeclaredFields()));
+		final Class<?> parentClass = type.getSuperclass();
+		
+		if (parentClass != null && !(parentClass.equals(Object.class))) {
+			List<Field> parentClassFields = getFieldsFromClassHierarchy(parentClass);
+			classFields.addAll(parentClassFields);
+		}
+		
+		return classFields;
+	}
+	
 	
 	
 	/**
@@ -53,9 +85,9 @@ public class ReflectionUtils {
 	 *            the callback that will be executed.
 	 * @param errorMessage
 	 *            the error message that is used in the exception when something went wrong.
-	 *
+	 *			
 	 * @return the return value of the given callback.
-	 *
+	 *		
 	 * @throws IllegalStateException
 	 *             when something went wrong.
 	 */
@@ -108,7 +140,7 @@ public class ReflectionUtils {
 	 *            the callback that will be executed.
 	 * @param errorMessage
 	 *            the error message that is used in the exception when something went wrong.
-	 *
+	 *			
 	 * @throws IllegalStateException
 	 *             when something went wrong.
 	 */

--- a/mvvmfx/src/main/java/de/saxsys/mvvmfx/internal/viewloader/ViewLoaderReflectionUtils.java
+++ b/mvvmfx/src/main/java/de/saxsys/mvvmfx/internal/viewloader/ViewLoaderReflectionUtils.java
@@ -9,8 +9,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -77,24 +75,11 @@ public class ViewLoaderReflectionUtils {
 	 * @return a list of fields.
 	 */
 	public static List<Field> getViewModelFields(Class<? extends View> viewType) {
-        return getFieldsFromClassHierarchy(viewType).stream()
+        return ReflectionUtils.getFieldsFromClassHierarchy(viewType).stream()
 				.filter(field -> field.isAnnotationPresent(InjectViewModel.class))
 				.collect(Collectors.toList());
 	}
 
-    public static List<Field> getFieldsFromClassHierarchy(Class<?> startClass) {
-
-        final List<Field> classFields = new ArrayList<>();
-        classFields.addAll(Arrays.asList(startClass.getDeclaredFields()));
-        final Class<?> parentClass = startClass.getSuperclass();
-
-        if (parentClass != null && !(parentClass.equals(Object.class))) {
-            List<Field> parentClassFields = getFieldsFromClassHierarchy(parentClass);
-            classFields.addAll(parentClassFields);
-        }
-
-        return classFields;
-    }
 
 	
 	

--- a/mvvmfx/src/main/java/de/saxsys/mvvmfx/internal/viewloader/ViewLoaderReflectionUtils.java
+++ b/mvvmfx/src/main/java/de/saxsys/mvvmfx/internal/viewloader/ViewLoaderReflectionUtils.java
@@ -1,6 +1,7 @@
 package de.saxsys.mvvmfx.internal.viewloader;
 
-import de.saxsys.mvvmfx.*;
+import de.saxsys.mvvmfx.InjectViewModel;
+import de.saxsys.mvvmfx.ViewModel;
 import net.jodah.typetools.TypeResolver;
 
 import java.lang.reflect.Field;
@@ -8,6 +9,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -75,10 +77,25 @@ public class ViewLoaderReflectionUtils {
 	 * @return a list of fields.
 	 */
 	public static List<Field> getViewModelFields(Class<? extends View> viewType) {
-		return Arrays.stream(viewType.getDeclaredFields())
+        return getFieldsFromClassHierarchy(viewType).stream()
 				.filter(field -> field.isAnnotationPresent(InjectViewModel.class))
 				.collect(Collectors.toList());
 	}
+
+    public static List<Field> getFieldsFromClassHierarchy(Class<?> startClass) {
+
+        final List<Field> classFields = new ArrayList<>();
+        classFields.addAll(Arrays.asList(startClass.getDeclaredFields()));
+        final Class<?> parentClass = startClass.getSuperclass();
+
+        if (parentClass != null && !(parentClass.equals(Object.class))) {
+            List<Field> parentClassFields = getFieldsFromClassHierarchy(parentClass);
+            classFields.addAll(parentClassFields);
+        }
+
+        return classFields;
+    }
+
 	
 	
 	/**


### PR DESCRIPTION
Fix #335 
To inject viewmodels and resourcebundles into views we need to search for annotated fields in the target classes. Until now we had only looked up the exact class type but ignored super classes.
This was leading to problems with Guice when AOP was used because guice was creating subclasses of the view class. In this case we where unable to find the needed fields.
From now on we are searching the whole class hierarchy (except Object itself) for fields.
