### PR TITLE
#310 other implementation of a state machine for synchronous commands

### DIFF
--- a/mvvmfx/src/test/java/de/saxsys/mvvmfx/utils/commands/CommandsWithoutUiThreadTest.java
+++ b/mvvmfx/src/test/java/de/saxsys/mvvmfx/utils/commands/CommandsWithoutUiThreadTest.java
@@ -1,0 +1,73 @@
+package de.saxsys.mvvmfx.utils.commands;
+
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.IntegerProperty;
+import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.property.SimpleIntegerProperty;
+import org.junit.Test;
+
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * There are use cases where the commands have to be used without a UI thread, for example when running unit tests.
+ * 
+ * To verify this behaviour we use a dedicated test class where we don't use a special JUnit runner for UI threading.
+ */
+public class CommandsWithoutUiThreadTest {
+	
+	public class MyViewModel {
+		
+		public IntegerProperty a = new SimpleIntegerProperty();
+		public IntegerProperty b = new SimpleIntegerProperty();
+		public IntegerProperty result = new SimpleIntegerProperty();
+		
+		private final DelegateCommand calcCommand;
+		
+		public MyViewModel() {
+			
+			BooleanProperty executable = new SimpleBooleanProperty();
+			executable.bind(a.greaterThan(0).and(b.greaterThan(0)));
+			
+			calcCommand = new DelegateCommand(() -> {
+				return new Action() {
+					@Override
+					protected void action() throws Exception {
+						result.set(a.get() + b.get());
+					}
+				};
+			}, executable, false);
+		}
+		
+		public Command calcCommand() {
+			return calcCommand;
+		}
+	}
+	
+	
+	@Test
+	public void test() {
+		
+		MyViewModel viewModel = new MyViewModel();
+		assertThat(viewModel.calcCommand.isExecutable()).isFalse();
+		assertThat(viewModel.result.get()).isEqualTo(0);
+		
+		
+		viewModel.a.setValue(2);
+		assertThat(viewModel.calcCommand.isExecutable()).isFalse();
+		assertThat(viewModel.result.get()).isEqualTo(0);
+		
+		viewModel.b.setValue(3);
+		assertThat(viewModel.calcCommand.isExecutable()).isTrue();
+		assertThat(viewModel.result.get()).isEqualTo(0);
+		
+		viewModel.calcCommand.execute();
+		
+		assertThat(viewModel.result.get()).isEqualTo(5);
+		
+	}
+	
+	
+	
+}

--- a/mvvmfx/src/test/java/de/saxsys/mvvmfx/utils/commands/DelegateCommandTest.java
+++ b/mvvmfx/src/test/java/de/saxsys/mvvmfx/utils/commands/DelegateCommandTest.java
@@ -9,6 +9,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import javafx.application.Platform;
 import javafx.beans.property.BooleanProperty;
@@ -57,11 +58,14 @@ public class DelegateCommandTest {
 		assertFalse(delegateCommand.isNotExecutable());
 	}
 	
+	
 	@Test
-	public void firePositive() throws InterruptedException, ExecutionException, TimeoutException {
+	public void executeSynchronousSucceeded() throws Exception {
 		BooleanProperty condition = new SimpleBooleanProperty(true);
 		BooleanProperty called = new SimpleBooleanProperty();
-		
+		BooleanProperty succeeded = new SimpleBooleanProperty();
+		BooleanProperty failed = new SimpleBooleanProperty();
+
 		DelegateCommand delegateCommand = new DelegateCommand(() -> new Action() {
 			@Override
 			protected void action() {
@@ -69,23 +73,67 @@ public class DelegateCommandTest {
 			}
 		}, condition);
 		
-		assertFalse(called.get());
-		delegateCommand.execute();
-		assertTrue(called.get());
-		
-		CompletableFuture<State> stateFromFxThread = new CompletableFuture<>();
-		Platform.runLater(() -> {
-			delegateCommand.stateProperty().addListener((b, o, n) -> {
-				if (n == State.SUCCEEDED) {
-					stateFromFxThread.complete(n);
-				}
-			});
+		delegateCommand.setOnSucceeded(workerStateEvent -> {
+			succeeded.set(true);
 		});
-		assertThat(stateFromFxThread.get(3, TimeUnit.SECONDS)).isEqualTo(State.SUCCEEDED);
+		
+		delegateCommand.setOnFailed(workerStateEvent -> {
+			failed.set(true);
+		});
+
+		// given
+		assertThat(called.get()).isFalse();
+		assertThat(succeeded.get()).isFalse();
+		assertThat(failed.get()).isFalse();
+		
+		// when
+		delegateCommand.execute();
+		
+		// then
+		assertThat(called.get()).isTrue();
+		assertThat(succeeded.get()).isTrue();
+		assertThat(failed.get()).isFalse();
+	}
+
+	@Test
+	public void executeSynchronousFailed() throws Exception {
+		BooleanProperty condition = new SimpleBooleanProperty(true);
+		BooleanProperty called = new SimpleBooleanProperty();
+		BooleanProperty succeeded = new SimpleBooleanProperty();
+		BooleanProperty failed = new SimpleBooleanProperty();
+
+		DelegateCommand delegateCommand = new DelegateCommand(() -> new Action() {
+			@Override
+			protected void action() {
+				called.set(true);
+				throw new RuntimeException("Some reason");
+			}
+		}, condition);
+
+		delegateCommand.setOnSucceeded(workerStateEvent -> {
+			succeeded.set(true);
+		});
+
+		delegateCommand.setOnFailed(workerStateEvent -> {
+			failed.set(true);
+		});
+
+		// given
+		assertThat(called.get()).isFalse();
+		assertThat(succeeded.get()).isFalse();
+		assertThat(failed.get()).isFalse();
+
+		// when
+		delegateCommand.execute();
+
+		// then
+		assertThat(called.get()).isTrue();
+		assertThat(succeeded.get()).isFalse();
+		assertThat(failed.get()).isTrue();
 	}
 	
 	@Test(expected = RuntimeException.class)
-	public void fireNegative() {
+	public void commandNotExecutable() {
 		BooleanProperty condition = new SimpleBooleanProperty(false);
 		
 		DelegateCommand delegateCommand = new DelegateCommand(() -> new Action() {
@@ -96,46 +144,6 @@ public class DelegateCommandTest {
 		
 		delegateCommand.execute();
 	}
-	
-	@Test
-	public void firePositiveWithExc() throws InterruptedException, ExecutionException, TimeoutException {
-		BooleanProperty throwExc = new SimpleBooleanProperty(true);
-		
-		DelegateCommand delegateCommand = new DelegateCommand(() -> new Action() {
-			@Override
-			protected void action() {
-				if (throwExc.get())
-					throw new RuntimeException("Someerror");
-			}
-		}, new SimpleBooleanProperty(true));
-		
-		
-		
-		CompletableFuture<State> stateFromFxThread1 = new CompletableFuture<>();
-		Platform.runLater(() -> {
-			delegateCommand.stateProperty().addListener((b, o, n) -> {
-				if (n == State.FAILED) {
-					stateFromFxThread1.complete(n);
-				}
-			});
-		});
-		Platform.runLater(() -> delegateCommand.execute());
-		assertThat(stateFromFxThread1.get(3, TimeUnit.SECONDS)).isEqualTo(State.FAILED);
-		
-		throwExc.set(false);
-		CompletableFuture<State> stateFromFxThread2 = new CompletableFuture<>();
-		Platform.runLater(() -> {
-			delegateCommand.stateProperty().addListener((b, o, n) -> {
-				if (n == State.SUCCEEDED) {
-					stateFromFxThread2.complete(n);
-				}
-			});
-		});
-		Platform.runLater(() -> delegateCommand.execute());
-		assertThat(stateFromFxThread2.get(3, TimeUnit.SECONDS)).isEqualTo(State.SUCCEEDED);
-		
-	}
-	
 	
 	@Test
 	public void longRunningAsync() throws Exception {


### PR DESCRIPTION
The previous fix for #310 introduced a breaking API change because the command execution of synchronous delegate commands was now done on the UI thread. 
This isn't the desired behaviour because it makes unit testing harder. 

The new implementation in this PR doesn't use the `reset` and `start` methods of `Service` but instead directly manipulates the state property. 

@sialcasa  please review this pull request and see if this is a suitable solution.
