### PR TITLE
Early return in calculateDifferenceFlag()

### DIFF
--- a/mvvmfx/src/main/java/de/saxsys/mvvmfx/utils/mapping/ModelWrapper.java
+++ b/mvvmfx/src/main/java/de/saxsys/mvvmfx/utils/mapping/ModelWrapper.java
@@ -702,11 +702,13 @@ public class ModelWrapper<M> {
 	
 	private void calculateDifferenceFlag() {
 		if (model.get() != null) {
-			final Optional<PropertyField<?, M, ?>> optional = fields.stream()
-					.filter(field -> field.isDifferent(model.get()))
-					.findAny();
-					
-			diffFlag.set(optional.isPresent());
+			for (final PropertyField<?, M, ?> field : fields) {
+                            if (field.isDifferent(model.get())) {
+                                diffFlag.set(true);
+                                return;
+                            }
+                        }
+                        diffFlag.set(false);
 		}
 	}
 	


### PR DESCRIPTION
Classic for-each seems to be a better approach than the Streams-API here. Allows early return and prevents new collection creation in the filter()-call.

I've refactored the ModelWrapper into a Kotlin-native implementation and would like to contribute it to the tornadoFX project (also Apache 2.0 licensed).
From what I've read about the licensing terms it's enough if I keep the original copyright notice at the top of the file? The Kotlin-implemenation doesn't need the accessorfunctions package and relies on higher-order functions instead.
