### PR TITLE
Fix NPE in ModelWrapper

### DIFF
--- a/mvvmfx/src/main/java/de/saxsys/mvvmfx/utils/mapping/ModelWrapper.java
+++ b/mvvmfx/src/main/java/de/saxsys/mvvmfx/utils/mapping/ModelWrapper.java
@@ -601,20 +601,30 @@ public class ModelWrapper<M> {
 	}
 
 	/**
-	 * Resets all defined fields to their default values. If no default value was defined <code>null</code> will be used
-	 * instead.
+	 * Resets all defined fields to their default values.
+	 * <p>
+	 * Default values can be defined as last argument of the overloaded "field" methods
+	 * (see {@link #field(StringGetter, StringSetter, String)})
+	 * or by using the {@link #useCurrentValuesAsDefaults()} method.
+	 *
+	 * <p>
+	 *
+	 * If no special default value was defined for a field the default value of the actual Property type will be used
+	 * (e.g. 0 for {@link IntegerProperty}, <code>null</code> for {@link StringProperty} and {@link ObjectProperty} ...).
+	 *
+	 *
 	 * <p>
 	 * <b>Note:</b> This method has no effects on the wrapped model element but will only change the values of the
 	 * defined property fields.
 	 */
 	public void reset() {
-		fields.forEach(field -> field.resetToDefault());
+		fields.forEach(PropertyField::resetToDefault);
 		
 		calculateDifferenceFlag();
 	}
 
 	/**
-	 * Use all values that are currently present in the wrapped model object as new default values for respective field.
+	 * Use all values that are currently present in the wrapped model object as new default values for respective fields.
 	 * This overrides/updates the values that were set during the initialization of the field mappings.
 	 * <p>
 	 * Subsequent calls to {@link #reset()} will reset the values to this new default values.
@@ -650,10 +660,16 @@ public class ModelWrapper<M> {
 	 *      
 	 * </pre>
 	 * 
+	 *
+	 * If no model instance is set to be wrapped by the ModelWrapper, nothing will happen when this method is invoked.
+	 * Instead the old default values will still be available.
+	 * 
 	 */
 	public void useCurrentValuesAsDefaults() {
-		for (final PropertyField<?, M, ?> field : fields) {
-			field.updateDefault(model.get());
+		if(model.get() != null) {
+			for (final PropertyField<?, M, ?> field : fields) {
+				field.updateDefault(model.get());
+			}
 		}
 	}
 
@@ -729,10 +745,10 @@ public class ModelWrapper<M> {
 	 * ModelWrapper{@code<Person>} personWrapper = new ModelWrapper{@code<>}();
 	 * 
 	 * StringProperty wrappedNameProperty = personWrapper.field(person -> person.getName(), (person, value)
-	 * 	 -> person.setName(value), "empty");
+	 * 	 -> person.setName(value));
 	 * 
 	 * // or with a method reference
-	 * StringProperty wrappedNameProperty = personWrapper.field(Person::getName, Person::setName, "empty");
+	 * StringProperty wrappedNameProperty = personWrapper.field(Person::getName, Person::setName);
 	 *
 	 * </pre>
 	 *

--- a/mvvmfx/src/test/java/de/saxsys/mvvmfx/utils/mapping/ModelWrapperTest.java
+++ b/mvvmfx/src/test/java/de/saxsys/mvvmfx/utils/mapping/ModelWrapperTest.java
@@ -16,7 +16,9 @@
 package de.saxsys.mvvmfx.utils.mapping;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.setAllowExtractingPrivateFields;
 
+import javafx.beans.property.SimpleIntegerProperty;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -584,4 +586,86 @@ public class ModelWrapperTest {
     assertThat(ageField.get()).isEqualTo(person1.getAge());
     assertThat(nicknames.get()).containsExactlyElementsOf(person1.getNicknames());
   }
+
+	@Test
+	public void testUseCurrentValuesAsDefaultWhenModelIsNull() {
+
+		ModelWrapper<Person> wrapper = new ModelWrapper<>();
+
+		StringProperty name = wrapper.field("name", Person::getName, Person::setName, "empty");
+		IntegerProperty age = wrapper.field("age", Person::getAge, Person::setAge, 12);
+
+		wrapper.reset();
+
+		assertThat(name.get()).isEqualTo("empty");
+		assertThat(age.get()).isEqualTo(12);
+
+		wrapper.useCurrentValuesAsDefaults();
+
+
+		wrapper.reset();
+
+		// still the old default values
+		assertThat(name.get()).isEqualTo("empty");
+		assertThat(age.get()).isEqualTo(12);
+
+	}
+
+	@Test
+	public void testDefaultValues() {
+		final Person person = new Person();
+		person.setName("horst");
+		person.setAge(32);
+		person.setNicknames(Arrays.asList("captain"));
+
+		ModelWrapper<Person> wrapperWithDefaults = new ModelWrapper<>();
+		ModelWrapper<Person> wrapperWithoutDefaults = new ModelWrapper<>();
+
+		StringProperty nameWithDefault = wrapperWithDefaults.field("name", Person::getName, Person::setName, "empty");
+		IntegerProperty ageWithDefault = wrapperWithDefaults.field("age", Person::getAge, Person::setAge, 12);
+
+
+		StringProperty nameWithoutDefault = wrapperWithoutDefaults.field("name", Person::getName, Person::setName);
+		IntegerProperty ageWithoutDefault = wrapperWithoutDefaults.field("age", Person::getAge, Person::setAge);
+
+		// default values are only used when #reset is called.
+		assertThat(nameWithDefault.get()).isNull();
+		assertThat(ageWithDefault.get()).isEqualTo(0);
+
+		assertThat(nameWithoutDefault.get()).isNull();
+		assertThat(ageWithoutDefault.get()).isEqualTo(0);
+
+
+
+		wrapperWithDefaults.reset();
+		wrapperWithoutDefaults.reset();
+
+		assertThat(nameWithDefault.get()).isEqualTo("empty");
+		assertThat(ageWithDefault.get()).isEqualTo(12);
+
+		assertThat(nameWithoutDefault.get()).isNull();
+		assertThat(ageWithoutDefault.get()).isEqualTo(0);
+
+
+
+		wrapperWithDefaults.set(person);
+		wrapperWithoutDefaults.set(person);
+
+		assertThat(nameWithDefault.get()).isEqualTo("horst");
+		assertThat(ageWithDefault.get()).isEqualTo(32);
+
+		assertThat(nameWithoutDefault.get()).isEqualTo("horst");
+		assertThat(ageWithoutDefault.get()).isEqualTo(32);
+
+
+
+		wrapperWithDefaults.reset();
+		wrapperWithoutDefaults.reset();
+
+		assertThat(nameWithDefault.get()).isEqualTo("empty");
+		assertThat(ageWithDefault.get()).isEqualTo(12);
+
+		assertThat(nameWithoutDefault.get()).isNull();
+		assertThat(ageWithoutDefault.get()).isEqualTo(0);
+	}
 }


### PR DESCRIPTION
- when useCurrentValuesAsDefault is invoked on a modelWrapper instance with no model set a NullPointerException was thrown
- added an additional test case for the default values handling
- improved javadoc
#404
