### PR TITLE
refactor CompositeValidator and CompositeValidationResult

### DIFF
--- a/mvvmfx/src/test/java/de/saxsys/mvvmfx/utils/validation/CustomValidationMessageTest.java
+++ b/mvvmfx/src/test/java/de/saxsys/mvvmfx/utils/validation/CustomValidationMessageTest.java
@@ -2,6 +2,7 @@ package de.saxsys.mvvmfx.utils.validation;
 
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
+import javafx.collections.ObservableList;
 import org.junit.Test;
 
 import java.util.function.Predicate;
@@ -34,7 +35,7 @@ public class CustomValidationMessageTest {
 	
 	
 	@Test
-	public void test() {
+	public void testValidator() {
 
 		StringProperty value = new SimpleStringProperty();
 		
@@ -59,8 +60,35 @@ public class CustomValidationMessageTest {
 		MyCustomValidationMessage myCustomValidationMessage = (MyCustomValidationMessage) validationMessage;
 		
 		assertThat(myCustomValidationMessage.getErrorValue()).isEqualTo(10.3);
+	}
+
+	@Test
+	public void testCompositeValidator() {
+		StringProperty value = new SimpleStringProperty("hallo welt");
+		final Predicate<String> notEmptyPredicate = v -> !v.trim().isEmpty();
+		final Predicate<String> lengthPredicate = v -> v.length() > 5;
+
+		Validator validator1 = new FunctionBasedValidator<>(value, notEmptyPredicate, MyCustomValidationMessage.factory(10.3));
+		Validator validator2 = new FunctionBasedValidator<>(value, lengthPredicate, MyCustomValidationMessage.factory(10.3));
 
 
+		CompositeValidator compositeValidator = new CompositeValidator(validator1, validator2);
+
+		ValidationStatus validationStatus = compositeValidator.getValidationStatus();
+
+
+		ObservableList<ValidationMessage> messages = validationStatus.getMessages();
+
+		assertThat(messages).isEmpty();
+
+
+		value.set("welt");
+
+		assertThat(messages).hasSize(1);
+
+		ValidationMessage validationMessage = messages.get(0);
+
+		assertThat(validationMessage).isInstanceOf(MyCustomValidationMessage.class);
 	}
 	
 }

--- a/mvvmfx/src/test/java/de/saxsys/mvvmfx/utils/validation/ValidationStatusTest.java
+++ b/mvvmfx/src/test/java/de/saxsys/mvvmfx/utils/validation/ValidationStatusTest.java
@@ -18,6 +18,7 @@ package de.saxsys.mvvmfx.utils.validation;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class ValidationStatusTest {
 	
@@ -88,8 +89,54 @@ public class ValidationStatusTest {
 		assertThat(status.getWarningMessages()).isEmpty();
 		assertThat(status.getErrorMessages()).isEmpty();
 		assertThat(status.getHighestMessage().isPresent()).isFalse();
-		
-		
 	}
-	
+
+	@Test
+	public void testUnmodifiableLists() {
+		ValidationStatus status = new ValidationStatus();
+
+		status.addMessage(ValidationMessage.error("test123"));
+		status.addMessage(ValidationMessage.warning("test456"));
+
+		assertThat(status.getMessages()).hasSize(2);
+		assertThat(status.getWarningMessages()).hasSize(1);
+		assertThat(status.getErrorMessages()).hasSize(1);
+
+
+		expectUnsupported(() -> {
+			status.getMessages().add(ValidationMessage.error("test"));
+		});
+		expectUnsupported(() -> {
+			status.getMessages().clear();
+		});
+
+
+		expectUnsupported(() -> {
+			status.getErrorMessages().add(ValidationMessage.error("test"));
+		});
+		expectUnsupported(() -> {
+			status.getErrorMessages().clear();
+		});
+
+		expectUnsupported(() -> {
+			status.getWarningMessages().add(ValidationMessage.warning("test"));
+		});
+		expectUnsupported(() -> {
+			status.getWarningMessages().clear();
+		});
+
+		assertThat(status.getMessages()).hasSize(2);
+		assertThat(status.getWarningMessages()).hasSize(1);
+		assertThat(status.getErrorMessages()).hasSize(1);
+	}
+
+
+	private void expectUnsupported(Runnable code) {
+		try{
+			code.run();
+			fail("expected UnsupportedOperationException");
+		} catch (UnsupportedOperationException e){
+		}
+	}
+
 }


### PR DESCRIPTION
Due to a change in 1.5.1 it wasn't possible to use subclasses of ValidationMessage together with CompositeValidator anymore.
The reason was an internal refactoring of the CompositeValidationResult class.
In this commit the class was refactored again and now uses another logic to both fix the original bug and still make
usage of custom ValidationMessage types possible.

Fix for #415
