### PR TITLE
503 migrate tests to junit5

### DIFF
--- a/examples/books-example/pom.xml
+++ b/examples/books-example/pom.xml
@@ -88,7 +88,11 @@
 			<artifactId>junit</artifactId>
 			<scope>test</scope>
 		</dependency>
-
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<scope>test</scope>
+		</dependency>
 		<dependency>
 			<groupId>org.assertj</groupId>
 			<artifactId>assertj-core</artifactId>

--- a/examples/books-example/src/test/java/de/saxsys/mvvmfx/examples/books/MainViewModelTest.java
+++ b/examples/books-example/src/test/java/de/saxsys/mvvmfx/examples/books/MainViewModelTest.java
@@ -3,8 +3,8 @@ package de.saxsys.mvvmfx.examples.books;
 import de.saxsys.mvvmfx.examples.books.backend.Error;
 import de.saxsys.mvvmfx.examples.books.backend.Book;
 import de.saxsys.mvvmfx.examples.books.backend.LibraryService;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -19,7 +19,7 @@ public class MainViewModelTest {
 	private MainViewModel viewModel;
 	private LibraryService libraryService;
 	
-	@Before
+	@BeforeEach
 	public void setup() {
 		libraryService = mock(LibraryService.class);
 		

--- a/examples/books-example/src/test/java/de/saxsys/mvvmfx/examples/books/backend/LibraryServiceMockTest.java
+++ b/examples/books-example/src/test/java/de/saxsys/mvvmfx/examples/books/backend/LibraryServiceMockTest.java
@@ -1,7 +1,7 @@
 package de.saxsys.mvvmfx.examples.books.backend;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
@@ -18,7 +18,7 @@ public class LibraryServiceMockTest {
 	
 	private Book theMetamorphosis;
 	
-	@Before
+	@BeforeEach
 	public void setup() {
 		libraryService = new LibraryServiceMockImpl();
 		

--- a/examples/contacts-example/pom.xml
+++ b/examples/contacts-example/pom.xml
@@ -93,8 +93,8 @@
 		</dependency>
 
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/examples/contacts-example/src/test/java/de/saxsys/mvvmfx/examples/contacts/AppTestFxIT.java
+++ b/examples/contacts-example/src/test/java/de/saxsys/mvvmfx/examples/contacts/AppTestFxIT.java
@@ -1,19 +1,19 @@
 package de.saxsys.mvvmfx.examples.contacts;
 
 import de.saxsys.mvvmfx.examples.contacts.App;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
 import org.testfx.api.FxRobot;
 import org.testfx.api.FxToolkit;
 
 import static org.testfx.api.FxAssert.verifyThat;
 import static org.testfx.matcher.control.TableViewMatchers.hasTableCell;
 
-@Ignore
+@Disabled
 public class AppTestFxIT extends FxRobot {
 
-	@Before
+	@BeforeEach
 	public void setupApp() throws Exception {
 
 		FxToolkit.registerPrimaryStage();

--- a/examples/contacts-example/src/test/java/de/saxsys/mvvmfx/examples/contacts/model/countries/CountrySelectorInterfaceTest.java
+++ b/examples/contacts-example/src/test/java/de/saxsys/mvvmfx/examples/contacts/model/countries/CountrySelectorInterfaceTest.java
@@ -5,7 +5,7 @@ import de.saxsys.mvvmfx.examples.contacts.model.Subdivision;
 import de.saxsys.mvvmfx.examples.contacts.model.countries.CountrySelector;
 import javafx.application.Platform;
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -16,12 +16,12 @@ import java.util.stream.Collectors;
 
 import static eu.lestard.assertj.javafx.api.Assertions.assertThat;
 
-public abstract class AbstractCountrySelectorTest {
+public interface CountrySelectorInterfaceTest {
 
-	protected abstract CountrySelector getCountrySelector();
+	CountrySelector getCountrySelector();
 
 	@Test
-	public void testLoadSubdivisions() throws Exception {
+	default void testLoadSubdivisions() throws Exception {
 		CountrySelector countrySelector = getCountrySelector();
 		runBlocked(countrySelector::init);
 
@@ -47,7 +47,7 @@ public abstract class AbstractCountrySelectorTest {
 	}
 
 	@Test
-	public void testLoadCountries() throws InterruptedException, ExecutionException, TimeoutException {
+	default void testLoadCountries() throws InterruptedException, ExecutionException, TimeoutException {
 		CountrySelector countrySelector = getCountrySelector();
 
 		runBlocked(countrySelector::init);
@@ -86,7 +86,7 @@ public abstract class AbstractCountrySelectorTest {
 		assertThat(countrySelector.subdivisionLabel()).hasNullValue();
 	}
 
-	protected void runBlocked(Runnable function) {
+	default void runBlocked(Runnable function) {
 		CompletableFuture<Boolean> blocker = new CompletableFuture<>();
 
 		getCountrySelector().inProgressProperty().addListener((obs, oldV, newV) -> {
@@ -104,15 +104,15 @@ public abstract class AbstractCountrySelectorTest {
 		}
 	}
 
-	protected Country getCountryByName(List<Country> countries, String name) {
+	default Country getCountryByName(List<Country> countries, String name) {
 		return countries.stream().filter(country -> country.getName().equals(name)).findFirst().orElse(null);
 	}
 
-	protected List<String> getSubdivisionNames(List<Subdivision> subdivisions) {
+	default List<String> getSubdivisionNames(List<Subdivision> subdivisions) {
 		return subdivisions.stream().map(Subdivision::getName).collect(Collectors.toList());
 	}
 
-	protected List<String> getCountryNames(List<Country> countries) {
+	default List<String> getCountryNames(List<Country> countries) {
 		return countries.stream().map(Country::getName).collect(Collectors.toList());
 	}
 }

--- a/examples/contacts-example/src/test/java/de/saxsys/mvvmfx/examples/contacts/model/countries/DataFxCountrySelectorIntegrationTest.java
+++ b/examples/contacts-example/src/test/java/de/saxsys/mvvmfx/examples/contacts/model/countries/DataFxCountrySelectorIntegrationTest.java
@@ -1,11 +1,11 @@
 package de.saxsys.mvvmfx.examples.contacts.model.countries;
 
 import de.saxsys.mvvmfx.examples.contacts.model.Country;
-import de.saxsys.mvvmfx.testingutils.jfxrunner.JfxRunner;
+import de.saxsys.mvvmfx.testingutils.JfxToolkitExtension;
 import org.datafx.reader.converter.XmlConverter;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.FileNotFoundException;
 import java.io.InputStream;
@@ -13,18 +13,17 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(JfxRunner.class)
-public class DataFxCountrySelectorIntegrationTest extends AbstractCountrySelectorTest {
+@ExtendWith(JfxToolkitExtension.class)
+public class DataFxCountrySelectorIntegrationTest implements CountrySelectorInterfaceTest {
 
 	private CountrySelector countrySelector;
 
 
-	@Override
-	protected CountrySelector getCountrySelector() {
+	@Override public CountrySelector getCountrySelector() {
 		return countrySelector;
 	}
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		countrySelector = new DataFxCountrySelector();
 	}

--- a/examples/contacts-example/src/test/java/de/saxsys/mvvmfx/examples/contacts/model/countries/DomCountrySelectorIntegrationTest.java
+++ b/examples/contacts-example/src/test/java/de/saxsys/mvvmfx/examples/contacts/model/countries/DomCountrySelectorIntegrationTest.java
@@ -1,22 +1,21 @@
 package de.saxsys.mvvmfx.examples.contacts.model.countries;
 
-import de.saxsys.mvvmfx.testingutils.jfxrunner.JfxRunner;
-import org.junit.Before;
-import org.junit.runner.RunWith;
+import de.saxsys.mvvmfx.testingutils.JfxToolkitExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@RunWith(JfxRunner.class)
-public class DomCountrySelectorIntegrationTest extends AbstractCountrySelectorTest {
+@ExtendWith(JfxToolkitExtension.class)
+public class DomCountrySelectorIntegrationTest implements CountrySelectorInterfaceTest {
 
 	private CountrySelector countrySelector;
 
-	@Before
+	@BeforeEach
 	public void setup(){
 		countrySelector = new DomCountrySelector();
 	}
 
 
-	@Override
-	protected CountrySelector getCountrySelector() {
+	@Override public CountrySelector getCountrySelector() {
 		return countrySelector;
 	}
 }

--- a/examples/contacts-example/src/test/java/de/saxsys/mvvmfx/examples/contacts/model/countries/JAXBCountrySelectorIntegrationTest.java
+++ b/examples/contacts-example/src/test/java/de/saxsys/mvvmfx/examples/contacts/model/countries/JAXBCountrySelectorIntegrationTest.java
@@ -1,24 +1,20 @@
 package de.saxsys.mvvmfx.examples.contacts.model.countries;
 
-import de.saxsys.mvvmfx.examples.contacts.model.countries.AbstractCountrySelectorTest;
-import de.saxsys.mvvmfx.examples.contacts.model.countries.CountrySelector;
-import de.saxsys.mvvmfx.examples.contacts.model.countries.JAXBCountrySelector;
-import de.saxsys.mvvmfx.testingutils.jfxrunner.JfxRunner;
-import org.junit.Before;
-import org.junit.runner.RunWith;
+import de.saxsys.mvvmfx.testingutils.JfxToolkitExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@RunWith(JfxRunner.class)
-public class JAXBCountrySelectorIntegrationTest extends AbstractCountrySelectorTest {
+@ExtendWith(JfxToolkitExtension.class)
+public class JAXBCountrySelectorIntegrationTest implements CountrySelectorInterfaceTest {
 
     private CountrySelector countrySelector;
 
-    @Before
+    @BeforeEach
     public void setup() {
         countrySelector = new JAXBCountrySelector();
     }
 
-    @Override
-    protected CountrySelector getCountrySelector() {
+    @Override public CountrySelector getCountrySelector() {
         return countrySelector;
     }
 }

--- a/examples/contacts-example/src/test/java/de/saxsys/mvvmfx/examples/contacts/model/validation/BirthdayValidatorTest.java
+++ b/examples/contacts-example/src/test/java/de/saxsys/mvvmfx/examples/contacts/model/validation/BirthdayValidatorTest.java
@@ -13,8 +13,8 @@ import de.saxsys.mvvmfx.utils.validation.Validator;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import de.saxsys.mvvmfx.examples.contacts.util.CentralClock;
 import de.saxsys.mvvmfx.utils.validation.ValidationStatus;
@@ -24,7 +24,7 @@ public class BirthdayValidatorTest {
 	private ValidationStatus result;
 	private ObjectProperty<LocalDate> value = new SimpleObjectProperty<>();
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		ZonedDateTime now = ZonedDateTime
 				.of(LocalDate.of(2014, Month.JANUARY, 1), LocalTime.of(0, 0), ZoneId.systemDefault());

--- a/examples/contacts-example/src/test/java/de/saxsys/mvvmfx/examples/contacts/model/validation/EmailAddressValidatorTest.java
+++ b/examples/contacts-example/src/test/java/de/saxsys/mvvmfx/examples/contacts/model/validation/EmailAddressValidatorTest.java
@@ -7,8 +7,8 @@ import de.saxsys.mvvmfx.utils.validation.Validator;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import de.saxsys.mvvmfx.utils.validation.ValidationStatus;
 
@@ -17,7 +17,7 @@ public class EmailAddressValidatorTest {
 	private ValidationStatus result;
 	private StringProperty value = new SimpleStringProperty();
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		Validator validator = new EmailValidator(value);
 

--- a/examples/contacts-example/src/test/java/de/saxsys/mvvmfx/examples/contacts/model/validation/PhoneNumberValidatorTest.java
+++ b/examples/contacts-example/src/test/java/de/saxsys/mvvmfx/examples/contacts/model/validation/PhoneNumberValidatorTest.java
@@ -7,8 +7,8 @@ import de.saxsys.mvvmfx.utils.validation.Validator;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import de.saxsys.mvvmfx.utils.validation.ValidationStatus;
 
@@ -17,7 +17,7 @@ public class PhoneNumberValidatorTest {
 	private ValidationStatus result;
 	private StringProperty value = new SimpleStringProperty();
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		Validator validator = new PhoneValidator(value, "error message");
 

--- a/examples/contacts-example/src/test/java/de/saxsys/mvvmfx/examples/contacts/ui/about/AboutViewModelTest.java
+++ b/examples/contacts-example/src/test/java/de/saxsys/mvvmfx/examples/contacts/ui/about/AboutViewModelTest.java
@@ -9,8 +9,8 @@ import java.util.function.Consumer;
 
 import javafx.beans.property.ReadOnlyStringProperty;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class AboutViewModelTest {
 
@@ -25,7 +25,7 @@ public class AboutViewModelTest {
 	private Consumer<String> onLinkClickedHandler;
 
 	@SuppressWarnings("unchecked")
-	@Before
+	@BeforeEach
 	public void setup() {
 		viewModel = new AboutViewModel();
 

--- a/examples/contacts-example/src/test/java/de/saxsys/mvvmfx/examples/contacts/ui/addressform/AddressFormViewModelTest.java
+++ b/examples/contacts-example/src/test/java/de/saxsys/mvvmfx/examples/contacts/ui/addressform/AddressFormViewModelTest.java
@@ -9,8 +9,8 @@ import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ListResourceBundle;
 import java.util.ResourceBundle;
@@ -39,7 +39,7 @@ public class AddressFormViewModelTest {
 
 	private ContactDialogScope scope;
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		availableCountries.addAll(germany, austria);
 

--- a/examples/contacts-example/src/test/java/de/saxsys/mvvmfx/examples/contacts/ui/contactdialog/ContactDialogViewModelTest.java
+++ b/examples/contacts-example/src/test/java/de/saxsys/mvvmfx/examples/contacts/ui/contactdialog/ContactDialogViewModelTest.java
@@ -2,8 +2,8 @@ package de.saxsys.mvvmfx.examples.contacts.ui.contactdialog;
 
 import de.saxsys.mvvmfx.examples.contacts.ui.scopes.ContactDialogScope;
 import javafx.beans.property.BooleanProperty;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static eu.lestard.assertj.javafx.api.Assertions.assertThat;
 
@@ -16,7 +16,7 @@ public class ContactDialogViewModelTest {
 	private BooleanProperty contactFormValid;
 	private BooleanProperty addressFormValid;
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		scope = new ContactDialogScope();
 		contactFormValid = scope.contactFormValidProperty();

--- a/examples/contacts-example/src/test/java/de/saxsys/mvvmfx/examples/contacts/ui/contactdialog/ContactFormViewModelTest.java
+++ b/examples/contacts-example/src/test/java/de/saxsys/mvvmfx/examples/contacts/ui/contactdialog/ContactFormViewModelTest.java
@@ -2,8 +2,8 @@ package de.saxsys.mvvmfx.examples.contacts.ui.contactdialog;
 
 import de.saxsys.mvvmfx.examples.contacts.ui.contactform.ContactFormViewModel;
 import de.saxsys.mvvmfx.testingutils.GCVerifier;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static eu.lestard.assertj.javafx.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -12,7 +12,7 @@ public class ContactFormViewModelTest {
 
 	private ContactFormViewModel viewModel;
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		viewModel = new ContactFormViewModel();
 	}

--- a/examples/contacts-example/src/test/java/de/saxsys/mvvmfx/examples/contacts/ui/detail/DetailViewModelTest.java
+++ b/examples/contacts-example/src/test/java/de/saxsys/mvvmfx/examples/contacts/ui/detail/DetailViewModelTest.java
@@ -7,8 +7,8 @@ import static org.mockito.Mockito.when;
 
 import java.time.LocalDate;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import de.saxsys.mvvmfx.examples.contacts.model.Contact;
 import de.saxsys.mvvmfx.examples.contacts.model.Repository;
@@ -26,7 +26,7 @@ public class DetailViewModelTest {
 
 	private Repository repository;
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		MasterDetailScope masterViewModelMock = mock(MasterDetailScope.class);
 

--- a/examples/contacts-example/src/test/java/de/saxsys/mvvmfx/examples/contacts/ui/editcontact/EditContactDialogViewModelTest.java
+++ b/examples/contacts-example/src/test/java/de/saxsys/mvvmfx/examples/contacts/ui/editcontact/EditContactDialogViewModelTest.java
@@ -7,7 +7,7 @@ import static org.mockito.Mockito.when;
 import java.util.ListResourceBundle;
 import java.util.ResourceBundle;
 
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 import de.saxsys.mvvmfx.examples.contacts.model.Repository;
 import de.saxsys.mvvmfx.examples.contacts.ui.contactdialog.ContactDialogViewModel;
@@ -25,7 +25,7 @@ public class EditContactDialogViewModelTest {
 
 	private ContactDialogScope scope;
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		scope = new ContactDialogScope();
 

--- a/examples/contacts-example/src/test/java/de/saxsys/mvvmfx/examples/contacts/ui/master/MasterTableViewModelTest.java
+++ b/examples/contacts-example/src/test/java/de/saxsys/mvvmfx/examples/contacts/ui/master/MasterTableViewModelTest.java
@@ -8,7 +8,7 @@ import java.time.Month;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import de.saxsys.mvvmfx.examples.contacts.model.Contact;
 import de.saxsys.mvvmfx.examples.contacts.util.CentralClock;

--- a/examples/contacts-example/src/test/java/de/saxsys/mvvmfx/examples/contacts/ui/master/MasterViewModelTest.java
+++ b/examples/contacts-example/src/test/java/de/saxsys/mvvmfx/examples/contacts/ui/master/MasterViewModelTest.java
@@ -11,8 +11,8 @@ import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import de.saxsys.mvvmfx.examples.contacts.events.ContactsUpdatedEvent;
 import de.saxsys.mvvmfx.examples.contacts.model.Contact;
@@ -34,7 +34,7 @@ public class MasterViewModelTest {
 
 	private Consumer<MasterTableViewModel> onSelectConsumer;
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		repository = new InmemoryRepository();
 		viewModel = new MasterViewModel();
@@ -143,12 +143,12 @@ public class MasterViewModelTest {
 	 * TableView.
 	 *
 	 * The TableView doesn't directly show instances of
-	 * {@link de.saxsys.mvvmfx.examples.contacts.model.Contact} but instead
+	 * {@link Contact} but instead
 	 * contains instances of
-	 * {@link de.saxsys.mvvmfx.examples.contacts.ui.master.MasterTableViewModel}.
+	 * {@link MasterTableViewModel}.
 	 *
 	 * Every
-	 * {@link de.saxsys.mvvmfx.examples.contacts.ui.master.MasterTableViewModel}
+	 * {@link MasterTableViewModel}
 	 * has an ID attribute corresponding to the ID of the contact that is shown.
 	 * This method extracts these IDs and returns them as List. This way we can
 	 * verify what Contacts are shown in the Table.
@@ -160,8 +160,8 @@ public class MasterViewModelTest {
 
 	/**
 	 * Returns the
-	 * {@link de.saxsys.mvvmfx.examples.contacts.ui.master.MasterTableViewModel}
-	 * for the given {@link de.saxsys.mvvmfx.examples.contacts.model.Contact}
+	 * {@link MasterTableViewModel}
+	 * for the given {@link Contact}
 	 * from the contact list.
 	 */
 	private MasterTableViewModel findTableViewModelForContact(Contact contact) {

--- a/examples/mini-examples/fx-root-example/pom.xml
+++ b/examples/mini-examples/fx-root-example/pom.xml
@@ -40,6 +40,10 @@
 			<artifactId>junit</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+		</dependency>
 
 		<dependency>
 			<groupId>org.loadui</groupId>

--- a/examples/mini-examples/fx-root-example/src/test/java/de/saxsys/mvvmfx/examples/fx_root_example/LabeledTextFieldTest.java
+++ b/examples/mini-examples/fx-root-example/src/test/java/de/saxsys/mvvmfx/examples/fx_root_example/LabeledTextFieldTest.java
@@ -2,14 +2,14 @@ package de.saxsys.mvvmfx.examples.fx_root_example;
 
 import static eu.lestard.assertj.javafx.api.Assertions.assertThat;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class LabeledTextFieldTest {
 	
 	private LabeledTextFieldViewModel viewModel;
 	
-	@Before
+	@BeforeEach
 	public void setup() {
 		viewModel = new LabeledTextFieldViewModel();
 	}

--- a/examples/mini-examples/welcome-example/pom.xml
+++ b/examples/mini-examples/welcome-example/pom.xml
@@ -40,8 +40,8 @@
 		</dependency>
 
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/examples/mini-examples/welcome-example/src/test/java/de/saxsys/mvvmfx/viewmodel/personlogin/PersonLoginViewModelTest.java
+++ b/examples/mini-examples/welcome-example/src/test/java/de/saxsys/mvvmfx/viewmodel/personlogin/PersonLoginViewModelTest.java
@@ -1,10 +1,10 @@
 package de.saxsys.mvvmfx.viewmodel.personlogin;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import javafx.collections.ObservableList;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import de.saxsys.mvvmfx.examples.welcome.model.Repository;
 import de.saxsys.mvvmfx.examples.welcome.viewmodel.personlogin.PersonLoginViewModel;

--- a/examples/mini-examples/welcome-example/src/test/java/de/saxsys/mvvmfx/viewmodel/personwelcome/PersonWelcomeViewModelTest.java
+++ b/examples/mini-examples/welcome-example/src/test/java/de/saxsys/mvvmfx/viewmodel/personwelcome/PersonWelcomeViewModelTest.java
@@ -1,9 +1,9 @@
 package de.saxsys.mvvmfx.viewmodel.personwelcome;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import de.saxsys.mvvmfx.examples.welcome.model.Gender;
 import de.saxsys.mvvmfx.examples.welcome.model.Person;
@@ -15,7 +15,7 @@ public class PersonWelcomeViewModelTest {
 	private Repository repository;
 	private PersonWelcomeViewModel personWelcomeViewModel;
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		// TODO: this should be mocked
 		repository = new Repository();

--- a/mvvmfx-cdi/pom.xml
+++ b/mvvmfx-cdi/pom.xml
@@ -75,8 +75,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/mvvmfx-cdi/pom.xml
+++ b/mvvmfx-cdi/pom.xml
@@ -34,7 +34,7 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.18.1</version>
+				<version>2.19.1</version>
 				<configuration>
 					<forkMode>always</forkMode>
 				</configuration>

--- a/mvvmfx-cdi/src/test/java/de/saxsys/mvvmfx/cdi/it/IntegrationTest.java
+++ b/mvvmfx-cdi/src/test/java/de/saxsys/mvvmfx/cdi/it/IntegrationTest.java
@@ -3,12 +3,12 @@ package de.saxsys.mvvmfx.cdi.it;
 import static org.assertj.core.api.Assertions.assertThat;
 import javafx.application.Application;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class IntegrationTest {
 	
-	@Before
+	@BeforeEach
 	public void setup() {
 		MyApp.wasPostConstructCalled = false;
 		MyApp.wasPreDestroyCalled = false;

--- a/mvvmfx-guice/pom.xml
+++ b/mvvmfx-guice/pom.xml
@@ -33,7 +33,7 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.18.1</version>
+				<version>2.19.1</version>
 				<configuration>
 					<forkMode>always</forkMode>
 				</configuration>

--- a/mvvmfx-guice/pom.xml
+++ b/mvvmfx-guice/pom.xml
@@ -63,8 +63,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/mvvmfx-guice/src/test/java/de/saxsys/mvvmfx/guice/DuplicateInjectionBugTest.java
+++ b/mvvmfx-guice/src/test/java/de/saxsys/mvvmfx/guice/DuplicateInjectionBugTest.java
@@ -7,7 +7,7 @@ import javafx.stage.Stage;
 
 import javax.inject.Inject;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * This test is used to reproduce a bug in the mvvmfx-guice module. A class that is injected into the application is

--- a/mvvmfx-guice/src/test/java/de/saxsys/mvvmfx/guice/interceptiontest/InterceptorTest.java
+++ b/mvvmfx-guice/src/test/java/de/saxsys/mvvmfx/guice/interceptiontest/InterceptorTest.java
@@ -1,7 +1,7 @@
 package de.saxsys.mvvmfx.guice.interceptiontest;
 
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/mvvmfx-guice/src/test/java/de/saxsys/mvvmfx/guice/it/IntegrationTest.java
+++ b/mvvmfx-guice/src/test/java/de/saxsys/mvvmfx/guice/it/IntegrationTest.java
@@ -1,14 +1,14 @@
 package de.saxsys.mvvmfx.guice.it;
 
 import de.saxsys.mvvmfx.guice.internal.GuiceInjector;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class IntegrationTest {
 	
-	@Before
+	@BeforeEach
 	public void setup() {
 		MyApp.wasInitCalled = false;
 		MyApp.wasStopCalled = false;

--- a/mvvmfx-testing-utils/pom.xml
+++ b/mvvmfx-testing-utils/pom.xml
@@ -28,6 +28,11 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <scope>test</scope>

--- a/mvvmfx-testing-utils/src/main/java/de/saxsys/mvvmfx/testingutils/FxTestingUtils.java
+++ b/mvvmfx-testing-utils/src/main/java/de/saxsys/mvvmfx/testingutils/FxTestingUtils.java
@@ -10,10 +10,15 @@ import java.util.concurrent.TimeoutException;
 public class FxTestingUtils {
 
 
-	public static void waitForUiThread(long timeout) {
+	public static void runInFXThread(Runnable code){
+		runInFXThread(code, 1000);
+	}
+
+	public static void runInFXThread(Runnable code, long timeout){
 		CompletableFuture<Void> future = new CompletableFuture<>();
 
 		Platform.runLater(() -> {
+			code.run();
 			future.complete(null);
 		});
 
@@ -24,7 +29,19 @@ public class FxTestingUtils {
 		}
 	}
 
+	/**
+	 * This method is used to wait until the UI thread has done all work that was queued via
+	 * {@link Platform#runLater(Runnable)}.
+	 */
+	public static void waitForUiThread(long timeout) {
+		runInFXThread(() -> {}, timeout);
+	}
+
+	/**
+	 * This method is used to wait until the UI thread has done all work that was queued via
+	 * {@link Platform#runLater(Runnable)}.
+	 */
 	public static void waitForUiThread() {
-		waitForUiThread(0);
+		waitForUiThread(1000);
 	}
 }

--- a/mvvmfx-testing-utils/src/main/java/de/saxsys/mvvmfx/testingutils/JfxToolkitExtension.java
+++ b/mvvmfx-testing-utils/src/main/java/de/saxsys/mvvmfx/testingutils/JfxToolkitExtension.java
@@ -1,0 +1,11 @@
+package de.saxsys.mvvmfx.testingutils;
+
+import javafx.embed.swing.JFXPanel;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class JfxToolkitExtension implements BeforeAllCallback {
+	@Override public void beforeAll(ExtensionContext extensionContext) throws Exception {
+		new JFXPanel();
+	}
+}

--- a/mvvmfx-testing-utils/src/test/java/de/saxsys/mvvmfx/testingutils/GCVerifierTest.java
+++ b/mvvmfx-testing-utils/src/test/java/de/saxsys/mvvmfx/testingutils/GCVerifierTest.java
@@ -1,6 +1,6 @@
 package de.saxsys.mvvmfx.testingutils;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;

--- a/mvvmfx-utils/pom.xml
+++ b/mvvmfx-utils/pom.xml
@@ -30,8 +30,8 @@
         <!-- Testing Frameworks -->
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/mvvmfx-utils/src/test/java/de/saxsys/mvvmfx/utils/listener/ListenerManagerTest.java
+++ b/mvvmfx-utils/src/test/java/de/saxsys/mvvmfx/utils/listener/ListenerManagerTest.java
@@ -25,8 +25,8 @@ import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
 import javafx.collections.FXCollections;
 import javafx.collections.ListChangeListener;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
@@ -53,7 +53,7 @@ public class ListenerManagerTest {
 	
 	private ListenerManager manager;
 	
-	@Before
+	@BeforeEach
 	public void setup() {
 		manager = new ListenerManager();
 		simpleListProperty.set(FXCollections.<String> observableArrayList());

--- a/mvvmfx-utils/src/test/java/de/saxsys/mvvmfx/utils/sizebinding/BindSizeToControlTest.java
+++ b/mvvmfx-utils/src/test/java/de/saxsys/mvvmfx/utils/sizebinding/BindSizeToControlTest.java
@@ -20,15 +20,15 @@ import static de.saxsys.mvvmfx.utils.sizebinding.SizeBindingsBuilder.*;
 import javafx.scene.control.Control;
 import javafx.scene.control.ScrollPane;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class BindSizeToControlTest extends SizeBindingsBuilderTestBase {
 	
 	private Control toControl;
 	
 	
-	@Before
+	@BeforeEach
 	public void setUp() {
 		toControl = new ScrollPane();
 	}

--- a/mvvmfx-utils/src/test/java/de/saxsys/mvvmfx/utils/sizebinding/BindSizeToImageViewTest.java
+++ b/mvvmfx-utils/src/test/java/de/saxsys/mvvmfx/utils/sizebinding/BindSizeToImageViewTest.java
@@ -19,14 +19,14 @@ import static de.saxsys.mvvmfx.utils.sizebinding.SizeBindingsBuilder.*;
 
 import javafx.scene.image.ImageView;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class BindSizeToImageViewTest extends SizeBindingsBuilderTestBase {
 	private ImageView toImageView;
 	
 	
-	@Before
+	@BeforeEach
 	public void setUp() {
 		toImageView = new ImageView();
 	}

--- a/mvvmfx-utils/src/test/java/de/saxsys/mvvmfx/utils/sizebinding/BindSizeToRectangleTest.java
+++ b/mvvmfx-utils/src/test/java/de/saxsys/mvvmfx/utils/sizebinding/BindSizeToRectangleTest.java
@@ -19,8 +19,8 @@ import static de.saxsys.mvvmfx.utils.sizebinding.SizeBindingsBuilder.*;
 
 import javafx.scene.shape.Rectangle;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class BindSizeToRectangleTest extends SizeBindingsBuilderTestBase {
 	
@@ -30,7 +30,7 @@ public class BindSizeToRectangleTest extends SizeBindingsBuilderTestBase {
 	/**
 	 * Create elements which will bind to each other.
 	 */
-	@Before
+	@BeforeEach
 	public void setUp() {
 		toRectangle = new Rectangle();
 	}

--- a/mvvmfx-utils/src/test/java/de/saxsys/mvvmfx/utils/sizebinding/BindSizeToRegionTest.java
+++ b/mvvmfx-utils/src/test/java/de/saxsys/mvvmfx/utils/sizebinding/BindSizeToRegionTest.java
@@ -19,15 +19,15 @@ import static de.saxsys.mvvmfx.utils.sizebinding.SizeBindingsBuilder.*;
 
 import javafx.scene.layout.Region;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class BindSizeToRegionTest extends SizeBindingsBuilderTestBase {
 	
 	private Region toRegion;
 	
 	
-	@Before
+	@BeforeEach
 	public void setUp() {
 		toRegion = new Region();
 	}

--- a/mvvmfx-utils/src/test/java/de/saxsys/mvvmfx/utils/sizebinding/SizeBindingsBuilderTestBase.java
+++ b/mvvmfx-utils/src/test/java/de/saxsys/mvvmfx/utils/sizebinding/SizeBindingsBuilderTestBase.java
@@ -17,7 +17,7 @@ package de.saxsys.mvvmfx.utils.sizebinding;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import de.saxsys.mvvmfx.testingutils.jfxrunner.JfxRunner;
+import de.saxsys.mvvmfx.testingutils.JfxToolkitExtension;
 import javafx.beans.property.ReadOnlyDoubleWrapper;
 import javafx.scene.control.Control;
 import javafx.scene.control.ScrollPane;
@@ -25,12 +25,12 @@ import javafx.scene.image.ImageView;
 import javafx.scene.layout.Region;
 import javafx.scene.shape.Rectangle;
 
-import org.junit.Before;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.internal.util.reflection.Whitebox;
 
 
-@RunWith(JfxRunner.class)
+@ExtendWith(JfxToolkitExtension.class)
 public abstract class SizeBindingsBuilderTestBase {
 	
 	protected static final double SIZEVAL = 100d;
@@ -43,7 +43,7 @@ public abstract class SizeBindingsBuilderTestBase {
 	
 	protected ImageView fromImageView;
 	
-	@Before
+	@BeforeEach
 	public void setup() {
 		fromRegion = new Region();
 		mockSize(fromRegion);

--- a/mvvmfx-utils/src/test/java/de/saxsys/mvvmfx/utils/sizebinding/UnbindHeightTest.java
+++ b/mvvmfx-utils/src/test/java/de/saxsys/mvvmfx/utils/sizebinding/UnbindHeightTest.java
@@ -24,8 +24,8 @@ import javafx.scene.image.ImageView;
 import javafx.scene.layout.Region;
 import javafx.scene.shape.Rectangle;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class UnbindHeightTest extends SizeBindingsBuilderTestBase {
 	
@@ -35,7 +35,7 @@ public class UnbindHeightTest extends SizeBindingsBuilderTestBase {
 	private Region targetRegion;
 	
 	
-	@Before
+	@BeforeEach
 	public void setUp() {
 		targetImageView = new ImageView();
 		targetControl = new ScrollPane();

--- a/mvvmfx-utils/src/test/java/de/saxsys/mvvmfx/utils/sizebinding/UnbindSizeTest.java
+++ b/mvvmfx-utils/src/test/java/de/saxsys/mvvmfx/utils/sizebinding/UnbindSizeTest.java
@@ -20,8 +20,8 @@ import javafx.scene.control.ScrollPane;
 import javafx.scene.image.ImageView;
 import javafx.scene.layout.Region;
 import javafx.scene.shape.Rectangle;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static de.saxsys.mvvmfx.utils.sizebinding.SizeBindingsBuilder.bindSize;
 import static de.saxsys.mvvmfx.utils.sizebinding.SizeBindingsBuilder.unbindSize;
@@ -35,7 +35,7 @@ public class UnbindSizeTest extends SizeBindingsBuilderTestBase {
 	private Region targetRegion;
 	
 	
-	@Before
+	@BeforeEach
 	public void setUp() {
 		targetImageView = new ImageView();
 		targetControl = new ScrollPane();

--- a/mvvmfx-utils/src/test/java/de/saxsys/mvvmfx/utils/sizebinding/UnbindWidthTest.java
+++ b/mvvmfx-utils/src/test/java/de/saxsys/mvvmfx/utils/sizebinding/UnbindWidthTest.java
@@ -24,8 +24,8 @@ import javafx.scene.image.ImageView;
 import javafx.scene.layout.Region;
 import javafx.scene.shape.Rectangle;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 
 public class UnbindWidthTest extends SizeBindingsBuilderTestBase {
@@ -37,7 +37,7 @@ public class UnbindWidthTest extends SizeBindingsBuilderTestBase {
 	private Region targetRegion;
 	
 	
-	@Before
+	@BeforeEach
 	public void setUp() {
 		targetImageView = new ImageView();
 		targetControl = new ScrollPane();

--- a/mvvmfx-validation/pom.xml
+++ b/mvvmfx-validation/pom.xml
@@ -49,8 +49,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/mvvmfx-validation/src/test/java/de/saxsys/mvvmfx/utils/validation/CompositeValidatorTest.java
+++ b/mvvmfx-validation/src/test/java/de/saxsys/mvvmfx/utils/validation/CompositeValidatorTest.java
@@ -19,8 +19,8 @@ import com.google.common.base.Strings;
 import javafx.beans.binding.Bindings;
 import javafx.beans.binding.IntegerBinding;
 import javafx.beans.property.*;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.function.Predicate;
@@ -41,7 +41,7 @@ public class CompositeValidatorTest {
 	private ObservableRuleBasedValidator validator1;
 	private ObservableRuleBasedValidator validator2;
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		validator1 = new ObservableRuleBasedValidator();
 		validator1.addRule(valid1, ValidationMessage.error("error1"));

--- a/mvvmfx-validation/src/test/java/de/saxsys/mvvmfx/utils/validation/CustomValidationMessageTest.java
+++ b/mvvmfx-validation/src/test/java/de/saxsys/mvvmfx/utils/validation/CustomValidationMessageTest.java
@@ -3,7 +3,7 @@ package de.saxsys.mvvmfx.utils.validation;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 import javafx.collections.ObservableList;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.function.Predicate;
 

--- a/mvvmfx-validation/src/test/java/de/saxsys/mvvmfx/utils/validation/FunctionBasedValidatorTest.java
+++ b/mvvmfx-validation/src/test/java/de/saxsys/mvvmfx/utils/validation/FunctionBasedValidatorTest.java
@@ -17,7 +17,7 @@ package de.saxsys.mvvmfx.utils.validation;
 
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.function.Function;
 import java.util.function.Predicate;

--- a/mvvmfx-validation/src/test/java/de/saxsys/mvvmfx/utils/validation/HighestMessageBugTest.java
+++ b/mvvmfx-validation/src/test/java/de/saxsys/mvvmfx/utils/validation/HighestMessageBugTest.java
@@ -24,8 +24,8 @@ import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 import javafx.collections.ListChangeListener;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * This test case reproduces the bug <a href="https://github.com/sialcasa/mvvmFX/issues/264">#264</a>
@@ -40,7 +40,7 @@ public class HighestMessageBugTest {
 	private ValidationStatus validationStatus;
 	
 	
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		value = new SimpleStringProperty("");
 		validator = new FunctionBasedValidator<>(value, v -> v != null, ValidationMessage.error("error"));

--- a/mvvmfx-validation/src/test/java/de/saxsys/mvvmfx/utils/validation/ObservableRulesTest.java
+++ b/mvvmfx-validation/src/test/java/de/saxsys/mvvmfx/utils/validation/ObservableRulesTest.java
@@ -18,7 +18,7 @@ package de.saxsys.mvvmfx.utils.validation;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 import javafx.beans.value.ObservableBooleanValue;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.regex.Pattern;
 

--- a/mvvmfx-validation/src/test/java/de/saxsys/mvvmfx/utils/validation/ObservableRulesValidatorTest.java
+++ b/mvvmfx-validation/src/test/java/de/saxsys/mvvmfx/utils/validation/ObservableRulesValidatorTest.java
@@ -17,8 +17,8 @@ package de.saxsys.mvvmfx.utils.validation;
 
 import de.saxsys.mvvmfx.testingutils.GCVerifier;
 import javafx.beans.property.*;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.regex.Pattern;
 
@@ -33,7 +33,7 @@ public class ObservableRulesValidatorTest {
 
 	private ObservableRuleBasedValidator validator;
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		rule1 = new SimpleBooleanProperty();
 		rule2 = new SimpleBooleanProperty();

--- a/mvvmfx-validation/src/test/java/de/saxsys/mvvmfx/utils/validation/ValidationMessageTest.java
+++ b/mvvmfx-validation/src/test/java/de/saxsys/mvvmfx/utils/validation/ValidationMessageTest.java
@@ -17,7 +17,7 @@ package de.saxsys.mvvmfx.utils.validation;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ValidationMessageTest {
 

--- a/mvvmfx-validation/src/test/java/de/saxsys/mvvmfx/utils/validation/ValidationStatusTest.java
+++ b/mvvmfx-validation/src/test/java/de/saxsys/mvvmfx/utils/validation/ValidationStatusTest.java
@@ -15,7 +15,7 @@
  ******************************************************************************/
 package de.saxsys.mvvmfx.utils.validation;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;

--- a/mvvmfx/pom.xml
+++ b/mvvmfx/pom.xml
@@ -57,6 +57,11 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-all</artifactId>
 			<scope>test</scope>

--- a/mvvmfx/pom.xml
+++ b/mvvmfx/pom.xml
@@ -52,11 +52,6 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-api</artifactId>
 			<scope>test</scope>

--- a/mvvmfx/src/test/java/FxmlViewinDefaultPackageTest.java
+++ b/mvvmfx/src/test/java/FxmlViewinDefaultPackageTest.java
@@ -16,9 +16,10 @@
 import de.saxsys.mvvmfx.FluentViewLoader;
 import de.saxsys.mvvmfx.ViewTuple;
 import de.saxsys.mvvmfx.internal.viewloader.example.TestViewModel;
-import de.saxsys.mvvmfx.testingutils.jfxrunner.JfxRunner;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import de.saxsys.mvvmfx.testingutils.JfxToolkitExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -27,7 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * 
  * A FxmlView located in the default package couldn't be loaded because a NullPointerException was thrown.
  */
-@RunWith(JfxRunner.class)
+@ExtendWith(JfxToolkitExtension.class)
 public class FxmlViewinDefaultPackageTest {
 	
 	

--- a/mvvmfx/src/test/java/de/saxsys/mvvmfx/internal/viewloader/DependencyInjectorTest.java
+++ b/mvvmfx/src/test/java/de/saxsys/mvvmfx/internal/viewloader/DependencyInjectorTest.java
@@ -20,12 +20,12 @@ import static org.junit.Assert.fail;
 import javafx.util.Callback;
 
 import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 /**
- * This test verifies the behaviour of the {@link de.saxsys.mvvmfx.internal.viewloader.DependencyInjector}.
+ * This test verifies the behaviour of the {@link DependencyInjector}.
  */
 public class DependencyInjectorTest {
 	
@@ -57,7 +57,7 @@ public class DependencyInjectorTest {
 		}
 	}
 	
-	@Before
+	@BeforeEach
 	public void setup() {
 		injector = new DependencyInjector();
 	}

--- a/mvvmfx/src/test/java/de/saxsys/mvvmfx/internal/viewloader/FluentViewLoader_API_Test.java
+++ b/mvvmfx/src/test/java/de/saxsys/mvvmfx/internal/viewloader/FluentViewLoader_API_Test.java
@@ -27,8 +27,8 @@ import de.saxsys.mvvmfx.internal.viewloader.example.TestFxmlViewFxRoot;
 import de.saxsys.mvvmfx.ViewTuple;
 import javafx.scene.layout.VBox;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import de.saxsys.mvvmfx.internal.viewloader.example.TestFxmlView;
 import de.saxsys.mvvmfx.internal.viewloader.example.TestJavaView;
@@ -36,7 +36,7 @@ import de.saxsys.mvvmfx.internal.viewloader.example.TestViewModel;
 
 
 /**
- * This test verifies the API of the {@link de.saxsys.mvvmfx.FluentViewLoader}. The functionality of loading Views is
+ * This test verifies the API of the {@link FluentViewLoader}. The functionality of loading Views is
  * not part of this test as it is already tested in other tests for the ViewLoader itself.
  */
 public class FluentViewLoader_API_Test {
@@ -44,7 +44,7 @@ public class FluentViewLoader_API_Test {
 	
 	private ResourceBundle resourceBundle;
 	
-	@Before
+	@BeforeEach
 	public void setup() throws IOException {
 		resourceBundle = new PropertyResourceBundle(new StringReader(""));
 	}

--- a/mvvmfx/src/test/java/de/saxsys/mvvmfx/internal/viewloader/FluentViewLoader_FxmlView_Test.java
+++ b/mvvmfx/src/test/java/de/saxsys/mvvmfx/internal/viewloader/FluentViewLoader_FxmlView_Test.java
@@ -21,12 +21,13 @@ import de.saxsys.mvvmfx.ViewModel;
 import de.saxsys.mvvmfx.ViewTuple;
 import de.saxsys.mvvmfx.internal.viewloader.example.*;
 import de.saxsys.mvvmfx.testingutils.ExceptionUtils;
-import de.saxsys.mvvmfx.testingutils.jfxrunner.JfxRunner;
+import de.saxsys.mvvmfx.testingutils.JfxToolkitExtension;
 import javafx.fxml.LoadException;
 import javafx.scene.layout.VBox;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.IOException;
 import java.io.StringReader;
@@ -42,12 +43,12 @@ import static org.assertj.core.api.Assertions.fail;
  * 
  * @author manuel.mauky
  */
-@RunWith(JfxRunner.class)
+@ExtendWith(JfxToolkitExtension.class)
 public class FluentViewLoader_FxmlView_Test {
 	
 	private ResourceBundle resourceBundle;
 	
-	@Before
+	@BeforeEach
 	public void setup() throws Exception {
 		resourceBundle = new PropertyResourceBundle(new StringReader(""));
 	}
@@ -233,10 +234,13 @@ public class FluentViewLoader_FxmlView_Test {
 		}
 	}
 	
-	@Test(expected = RuntimeException.class)
+	@Test
 	public void testLoadFailNoSuchFxmlFile() {
-		ViewTuple<InvalidFxmlTestView, TestViewModel> viewTuple = FluentViewLoader.fxmlView(InvalidFxmlTestView.class)
-				.load();
+		Assertions.assertThrows(RuntimeException.class, () -> {
+			ViewTuple<InvalidFxmlTestView, TestViewModel> viewTuple = FluentViewLoader
+					.fxmlView(InvalidFxmlTestView.class)
+					.load();
+		});
 	}
 	
 	/**

--- a/mvvmfx/src/test/java/de/saxsys/mvvmfx/internal/viewloader/FluentViewLoader_JavaView_Test.java
+++ b/mvvmfx/src/test/java/de/saxsys/mvvmfx/internal/viewloader/FluentViewLoader_JavaView_Test.java
@@ -24,9 +24,9 @@ import de.saxsys.mvvmfx.internal.viewloader.example.TestViewModelWithResourceBun
 import de.saxsys.mvvmfx.testingutils.ExceptionUtils;
 import javafx.fxml.Initializable;
 import javafx.scene.layout.VBox;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.StringReader;
 import java.lang.reflect.Constructor;
@@ -41,32 +41,32 @@ import static org.assertj.core.api.Assertions.fail;
 
 
 /**
- * This test verifies that loading views of type {@link de.saxsys.mvvmfx.JavaView} works correctly.
+ * This test verifies that loading views of type {@link JavaView} works correctly.
  * 
  * This includes the handling of initialization and injection of the ViewModel and the resourceBundle.
  * 
  * The injection and initialization is similar to that of FXML files. It can be done explicit by the use of the
- * {@link javafx.fxml.Initializable} interface or implicit by using the naming conventions of the
+ * {@link Initializable} interface or implicit by using the naming conventions of the
  * {@link javafx.fxml.FXMLLoader}.
  * 
  * This naming conventions are:
  * <ul>
  *
- * <li>a public field of type {@link java.util.ResourceBundle} named "resources" gets the current ResourceBundle
+ * <li>a public field of type {@link ResourceBundle} named "resources" gets the current ResourceBundle
  * injected.</li>
  * <li>a public no-arg method named "initialize" is called after the injection of other resources is finished.</li>
  *
  * </ul>
  *
  * The third convention of the FXMLLoader to inject the path of the FXML file to a public field of type
- * {@link java.net.URL} named "location" is NOT done by mvvmfx because it doesn't make sense for Java written Views (as
+ * {@link URL} named "location" is NOT done by mvvmfx because it doesn't make sense for Java written Views (as
  * there is no FXML file at all).
  */
 public class FluentViewLoader_JavaView_Test {
 	
 	private ResourceBundle resourceBundle;
 	
-	@Before
+	@BeforeEach
 	public void before() throws Exception {
 		resourceBundle = new PropertyResourceBundle(new StringReader(""));
 		
@@ -90,14 +90,14 @@ public class FluentViewLoader_JavaView_Test {
 		});
 	}
 	
-	@After
+	@AfterEach
 	public void after() {
 		MvvmFX.setCustomDependencyInjector(null);
 	}
 	
 	
 	/**
-	 * Verify that the loaded {@link de.saxsys.mvvmfx.ViewTuple} contains all expected references.
+	 * Verify that the loaded {@link ViewTuple} contains all expected references.
 	 */
 	@Test
 	public void testViewTuple() {
@@ -402,7 +402,7 @@ public class FluentViewLoader_JavaView_Test {
 	
 	
 	/**
-	 * When the {@link javafx.fxml.Initializable} interface is implemented, the implicit initialize method may not be
+	 * When the {@link Initializable} interface is implemented, the implicit initialize method may not be
 	 * called.
 	 */
 	@Test
@@ -497,7 +497,7 @@ public class FluentViewLoader_JavaView_Test {
 	
 	/**
 	 * The naming conventions say that the field for the resourceBundle may be named "resources". The injection is still
-	 * working when the type of the field is not {@link java.util.ResourceBundle}.
+	 * working when the type of the field is not {@link ResourceBundle}.
 	 */
 	@Test
 	public void testResourcesFieldHasOtherTypeAndIsStillInjected() {
@@ -548,7 +548,7 @@ public class FluentViewLoader_JavaView_Test {
 	}
 	
 	/**
-	 * When the {@link javafx.fxml.Initializable} interface is implemented, no implicit injection should be done.
+	 * When the {@link Initializable} interface is implemented, no implicit injection should be done.
 	 */
 	@Test
 	public void testResourceBundleIsNotInjectedImplicitWhenInitializeableIsImplemented() {

--- a/mvvmfx/src/test/java/de/saxsys/mvvmfx/internal/viewloader/FluentViewLoader_ResourceBundle_Test.java
+++ b/mvvmfx/src/test/java/de/saxsys/mvvmfx/internal/viewloader/FluentViewLoader_ResourceBundle_Test.java
@@ -29,18 +29,20 @@ import de.saxsys.mvvmfx.internal.viewloader.example.*;
 import de.saxsys.mvvmfx.resourcebundle.global.TestView;
 import de.saxsys.mvvmfx.resourcebundle.global.TestViewModel;
 import de.saxsys.mvvmfx.testingutils.ExceptionUtils;
+import de.saxsys.mvvmfx.testingutils.JfxToolkitExtension;
 import de.saxsys.mvvmfx.testingutils.jfxrunner.JfxRunner;
 import javafx.scene.layout.VBox;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import de.saxsys.mvvmfx.FluentViewLoader;
 import de.saxsys.mvvmfx.InjectResourceBundle;
 import de.saxsys.mvvmfx.JavaView;
 import de.saxsys.mvvmfx.ViewTuple;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.runner.RunWith;
 
 /**
@@ -49,14 +51,14 @@ import org.junit.runner.RunWith;
  * A resourceBundle can be injected into the View with default behaviour of JavaFX. Additionally the user can use the
  * mvvmfx annotation {@link InjectResourceBundle} to inject the resourceBundle in the View and in the ViewModel.
  */
-@RunWith(JfxRunner.class)
+@ExtendWith(JfxToolkitExtension.class)
 public class FluentViewLoader_ResourceBundle_Test {
 
 
 	private ResourceBundle resourceBundle;
 	private ResourceBundle globalResourceBundle;
 
-	@Before
+	@BeforeEach
 	public void setup() throws Exception {
 		resourceBundle = new ListResourceBundle() {
 			@Override
@@ -82,7 +84,7 @@ public class FluentViewLoader_ResourceBundle_Test {
 		MvvmFX.setGlobalResourceBundle(null);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		MvvmFX.setGlobalResourceBundle(null);
 	}
@@ -210,7 +212,7 @@ public class FluentViewLoader_ResourceBundle_Test {
 	 * but no resourceBundle was provided at loading time. Therefore an exception is thrown.
 	 */
 	@Test
-	//	@Ignore("until fixed. See issue #435")
+	//	@Disabled("until fixed. See issue #435")
 	public void fail_noResourceBundleGivenForViewAndViewModel() {
 		MvvmFX.setGlobalResourceBundle(null);
 

--- a/mvvmfx/src/test/java/de/saxsys/mvvmfx/internal/viewloader/MockableViewLoaderTest.java
+++ b/mvvmfx/src/test/java/de/saxsys/mvvmfx/internal/viewloader/MockableViewLoaderTest.java
@@ -16,7 +16,7 @@
 package de.saxsys.mvvmfx.internal.viewloader;
 
 import de.saxsys.mvvmfx.ViewTuple;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import de.saxsys.mvvmfx.FluentViewLoader;
 import de.saxsys.mvvmfx.internal.viewloader.example.TestFxmlView;

--- a/mvvmfx/src/test/java/de/saxsys/mvvmfx/internal/viewloader/ResourceBundleInjectorTest.java
+++ b/mvvmfx/src/test/java/de/saxsys/mvvmfx/internal/viewloader/ResourceBundleInjectorTest.java
@@ -21,8 +21,9 @@ import java.io.StringReader;
 import java.util.PropertyResourceBundle;
 import java.util.ResourceBundle;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import de.saxsys.mvvmfx.InjectResourceBundle;
 
@@ -33,7 +34,7 @@ public class ResourceBundleInjectorTest {
 	
 	private ResourceBundle resourceBundle;
 
-	@Before
+	@BeforeEach
 	public void setup() throws Exception {
 		resourceBundle = new PropertyResourceBundle(new StringReader(""));
 	}
@@ -66,7 +67,7 @@ public class ResourceBundleInjectorTest {
 		assertThat(example.resourceBundle).isEqualTo(resourceBundle);
 	}
 	
-	@Test(expected = IllegalStateException.class)
+	@Test
 	public void fail_wrongType() {
 		class Example {
 			@InjectResourceBundle
@@ -74,8 +75,10 @@ public class ResourceBundleInjectorTest {
 		}
 		
 		Example example = new Example();
-		
-		ResourceBundleInjector.injectResourceBundle(example, resourceBundle);
+
+		Assertions.assertThrows(IllegalStateException.class, () -> {
+			ResourceBundleInjector.injectResourceBundle(example, resourceBundle);
+		});
 	}
 	
 	@Test
@@ -91,7 +94,7 @@ public class ResourceBundleInjectorTest {
 		assertThat(example.resourceBundle).isNull();
 	}
 	
-	@Test(expected = IllegalStateException.class)
+	@Test
 	public void fail_annotationIsPresentButNoResourceBundleProvided() {
 		class Example {
 			@InjectResourceBundle
@@ -99,8 +102,10 @@ public class ResourceBundleInjectorTest {
 		}
 		
 		Example example = new Example();
-		
-		ResourceBundleInjector.injectResourceBundle(example, ResourceBundleManager.EMPTY_RESOURCE_BUNDLE);
+
+		Assertions.assertThrows(IllegalStateException.class, () -> {
+			ResourceBundleInjector.injectResourceBundle(example, ResourceBundleManager.EMPTY_RESOURCE_BUNDLE);
+		});
 	}
 	
 	/**
@@ -123,7 +128,7 @@ public class ResourceBundleInjectorTest {
 	 * If the annotation is present, even when the type of the field is wrong, an exception has to be thrown when no
 	 * resourceBundle was provided.
 	 */
-	@Test(expected = IllegalStateException.class)
+	@Test
 	public void fail_wrongTypeAndNoResourceBundleProvided() {
 		class Example {
 			@InjectResourceBundle
@@ -131,8 +136,10 @@ public class ResourceBundleInjectorTest {
 		}
 		
 		Example example = new Example();
-		
-		ResourceBundleInjector.injectResourceBundle(example, ResourceBundleManager.EMPTY_RESOURCE_BUNDLE);
+
+		Assertions.assertThrows(IllegalStateException.class, () -> {
+			ResourceBundleInjector.injectResourceBundle(example, ResourceBundleManager.EMPTY_RESOURCE_BUNDLE);
+		});
 	}
 	
 	
@@ -173,7 +180,7 @@ public class ResourceBundleInjectorTest {
 	/**
 	 * When the type of the field is wrong, an exception should be thrown even if the optional attribute is set to true.
 	 */
-	@Test(expected = IllegalStateException.class)
+	@Test
 	public void fail_optionalIsTrueButWrongType() {
 		class Example {
 			@InjectResourceBundle(optional = true)
@@ -181,8 +188,10 @@ public class ResourceBundleInjectorTest {
 		}
 		
 		Example example = new Example();
-		
-		ResourceBundleInjector.injectResourceBundle(example, resourceBundle);
+
+		Assertions.assertThrows(IllegalStateException.class, () -> {
+			ResourceBundleInjector.injectResourceBundle(example, resourceBundle);
+		});
 	}
 	
 	/**
@@ -200,9 +209,9 @@ public class ResourceBundleInjectorTest {
 		}
 		
 		Example example = new Example();
-		
+
 		ResourceBundleInjector.injectResourceBundle(example, resourceBundle);
-		
+
 		assertThat(example.resourceBundle).isEqualTo(resourceBundle);
 		assertThat(example.resourceBundleToo).isEqualTo(resourceBundle);
 	}
@@ -211,7 +220,7 @@ public class ResourceBundleInjectorTest {
 	 * When multiple fields are available, an exception is thrown when at least one of the fields has a wrong type. This
 	 * is true even if one of the fields is correct.
 	 */
-	@Test(expected = IllegalStateException.class)
+	@Test
 	public void fail_multipleResourceBundleFieldsOneHasWrongType() {
 		class Example {
 			@InjectResourceBundle
@@ -222,8 +231,10 @@ public class ResourceBundleInjectorTest {
 		}
 		
 		Example example = new Example();
-		
-		ResourceBundleInjector.injectResourceBundle(example, resourceBundle);
+
+		Assertions.assertThrows(IllegalStateException.class, () -> {
+			ResourceBundleInjector.injectResourceBundle(example, resourceBundle);
+		});
 	}
 	
 }

--- a/mvvmfx/src/test/java/de/saxsys/mvvmfx/internal/viewloader/ResourceBundleManagerTest.java
+++ b/mvvmfx/src/test/java/de/saxsys/mvvmfx/internal/viewloader/ResourceBundleManagerTest.java
@@ -15,8 +15,8 @@
  ******************************************************************************/
 package de.saxsys.mvvmfx.internal.viewloader;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ListResourceBundle;
 import java.util.MissingResourceException;
@@ -46,7 +46,7 @@ public class ResourceBundleManagerTest {
 	private ResourceBundle global;
 	private ResourceBundle other;
 	
-	@Before
+	@BeforeEach
 	public void setup(){
 		manager = new ResourceBundleManager();
 		

--- a/mvvmfx/src/test/java/de/saxsys/mvvmfx/internal/viewloader/ViewLoaderReflectionUtilsTest.java
+++ b/mvvmfx/src/test/java/de/saxsys/mvvmfx/internal/viewloader/ViewLoaderReflectionUtilsTest.java
@@ -18,7 +18,8 @@ package de.saxsys.mvvmfx.internal.viewloader;
 import de.saxsys.mvvmfx.ViewModel;
 import de.saxsys.mvvmfx.internal.viewloader.example.TestViewModel;
 import de.saxsys.mvvmfx.internal.viewloader.example.TestViewModelWithDoubleInjection;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -55,11 +56,13 @@ public class ViewLoaderReflectionUtilsTest {
 		assertThat(viewModel).isNull();
 	}
 
-	@Test(expected = IllegalStateException.class)
+	@Test
 	public void testDoubleInjection() {
 		class TestView implements View<TestViewModelWithDoubleInjection> {}
 
 		ViewModel viewModel = ViewLoaderReflectionUtils.createViewModel(new TestView());
-		ViewLoaderReflectionUtils.initializeViewModel(viewModel);
+		Assertions.assertThrows(IllegalStateException.class, () -> {
+			ViewLoaderReflectionUtils.initializeViewModel(viewModel);
+		});
 	}
 }

--- a/mvvmfx/src/test/java/de/saxsys/mvvmfx/internal/viewloader/lifecycle/LifecycleTest.java
+++ b/mvvmfx/src/test/java/de/saxsys/mvvmfx/internal/viewloader/lifecycle/LifecycleTest.java
@@ -15,20 +15,20 @@ import de.saxsys.mvvmfx.internal.viewloader.lifecycle.example_notification.Lifec
 import de.saxsys.mvvmfx.internal.viewloader.lifecycle.example_notification.LifecycleNotificationViewModel;
 import de.saxsys.mvvmfx.internal.viewloader.lifecycle.example_notification_without_lifecycle.NotificationWithoutLifecycleView;
 import de.saxsys.mvvmfx.internal.viewloader.lifecycle.example_notification_without_lifecycle.NotificationWithoutLifecycleViewModel;
+import de.saxsys.mvvmfx.testingutils.FxTestingUtils;
 import de.saxsys.mvvmfx.testingutils.GCVerifier;
-import de.saxsys.mvvmfx.testingutils.jfxrunner.JfxRunner;
-import de.saxsys.mvvmfx.testingutils.jfxrunner.TestInJfxThread;
+import de.saxsys.mvvmfx.testingutils.JfxToolkitExtension;
 import de.saxsys.mvvmfx.utils.notifications.DefaultNotificationCenter;
 import de.saxsys.mvvmfx.utils.notifications.NotificationCenterFactory;
 import javafx.scene.Scene;
 import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(JfxRunner.class)
+@ExtendWith(JfxToolkitExtension.class)
 public class LifecycleTest {
 
 	/**
@@ -42,68 +42,70 @@ public class LifecycleTest {
 	 * of the lifecycle.
 	 */
 	@Test
-	@TestInJfxThread
 	public void testLifecycleWithSubViewsWithoutGC() {
-		LifecycleTestRootViewModel.onViewAddedCalled = 0;
-		LifecycleTestRootViewModel.onViewRemovedCalled = 0;
-		LifecycleTestSub1ViewModel.onViewAddedCalled = 0;
-		LifecycleTestSub1ViewModel.onViewRemovedCalled = 0;
-		LifecycleTestSub2ViewModel.onViewAddedCalled = 0;
-		LifecycleTestSub2ViewModel.onViewRemovedCalled = 0;
+		FxTestingUtils.runInFXThread(() -> {
+			LifecycleTestRootViewModel.onViewAddedCalled = 0;
+			LifecycleTestRootViewModel.onViewRemovedCalled = 0;
+			LifecycleTestSub1ViewModel.onViewAddedCalled = 0;
+			LifecycleTestSub1ViewModel.onViewRemovedCalled = 0;
+			LifecycleTestSub2ViewModel.onViewAddedCalled = 0;
+			LifecycleTestSub2ViewModel.onViewRemovedCalled = 0;
 
-		ViewTuple<LifecycleTestRootView, LifecycleTestRootViewModel> viewTuple = FluentViewLoader.fxmlView(LifecycleTestRootView.class).load();
+			ViewTuple<LifecycleTestRootView, LifecycleTestRootViewModel> viewTuple = FluentViewLoader
+					.fxmlView(LifecycleTestRootView.class).load();
 
-		// the root view is not directly added to the Scene but encapsulated in
-		// another container
-		VBox subContainer = new VBox();
-		subContainer.getChildren().add(viewTuple.getView());
+			// the root view is not directly added to the Scene but encapsulated in
+			// another container
+			VBox subContainer = new VBox();
+			subContainer.getChildren().add(viewTuple.getView());
 
-		VBox container = new VBox();
+			VBox container = new VBox();
 
-		Stage stage = new Stage();
-		Scene scene = new Scene(container);
-		stage.setScene(scene);
-
-
-		// before adding to scene
-		assertThat(LifecycleTestRootViewModel.onViewAddedCalled).isEqualTo(0);
-		assertThat(LifecycleTestRootViewModel.onViewRemovedCalled).isEqualTo(0);
-		assertThat(LifecycleTestSub1ViewModel.onViewAddedCalled).isEqualTo(0);
-		assertThat(LifecycleTestSub1ViewModel.onViewRemovedCalled).isEqualTo(0);
-		assertThat(LifecycleTestSub2ViewModel.onViewAddedCalled).isEqualTo(0);
-		assertThat(LifecycleTestSub2ViewModel.onViewRemovedCalled).isEqualTo(0);
-
-		// add rootView to container
-		container.getChildren().add(subContainer);
-
-		assertThat(LifecycleTestRootViewModel.onViewAddedCalled).isEqualTo(1);
-		assertThat(LifecycleTestRootViewModel.onViewRemovedCalled).isEqualTo(0);
-		assertThat(LifecycleTestSub1ViewModel.onViewAddedCalled).isEqualTo(1);
-		assertThat(LifecycleTestSub1ViewModel.onViewRemovedCalled).isEqualTo(0);
-		assertThat(LifecycleTestSub2ViewModel.onViewAddedCalled).isEqualTo(1);
-		assertThat(LifecycleTestSub2ViewModel.onViewRemovedCalled).isEqualTo(0);
-
-		// remove from container
-		container.getChildren().clear();
-
-		assertThat(LifecycleTestRootViewModel.onViewAddedCalled).isEqualTo(1);
-		assertThat(LifecycleTestRootViewModel.onViewRemovedCalled).isEqualTo(1);
-		assertThat(LifecycleTestSub1ViewModel.onViewAddedCalled).isEqualTo(1);
-		assertThat(LifecycleTestSub1ViewModel.onViewRemovedCalled).isEqualTo(1);
-		assertThat(LifecycleTestSub2ViewModel.onViewAddedCalled).isEqualTo(1);
-		assertThat(LifecycleTestSub2ViewModel.onViewRemovedCalled).isEqualTo(1);
+			Stage stage = new Stage();
+			Scene scene = new Scene(container);
+			stage.setScene(scene);
 
 
-		// add again to container
-		container.getChildren().add(subContainer);
+			// before adding to scene
+			assertThat(LifecycleTestRootViewModel.onViewAddedCalled).isEqualTo(0);
+			assertThat(LifecycleTestRootViewModel.onViewRemovedCalled).isEqualTo(0);
+			assertThat(LifecycleTestSub1ViewModel.onViewAddedCalled).isEqualTo(0);
+			assertThat(LifecycleTestSub1ViewModel.onViewRemovedCalled).isEqualTo(0);
+			assertThat(LifecycleTestSub2ViewModel.onViewAddedCalled).isEqualTo(0);
+			assertThat(LifecycleTestSub2ViewModel.onViewRemovedCalled).isEqualTo(0);
 
-		// the lifecycle methods are invoked again
-		assertThat(LifecycleTestRootViewModel.onViewAddedCalled).isEqualTo(2);
-		assertThat(LifecycleTestRootViewModel.onViewRemovedCalled).isEqualTo(1);
-		assertThat(LifecycleTestSub1ViewModel.onViewAddedCalled).isEqualTo(2);
-		assertThat(LifecycleTestSub1ViewModel.onViewRemovedCalled).isEqualTo(1);
-		assertThat(LifecycleTestSub2ViewModel.onViewAddedCalled).isEqualTo(2);
-		assertThat(LifecycleTestSub2ViewModel.onViewRemovedCalled).isEqualTo(1);
+			// add rootView to container
+			container.getChildren().add(subContainer);
+
+			assertThat(LifecycleTestRootViewModel.onViewAddedCalled).isEqualTo(1);
+			assertThat(LifecycleTestRootViewModel.onViewRemovedCalled).isEqualTo(0);
+			assertThat(LifecycleTestSub1ViewModel.onViewAddedCalled).isEqualTo(1);
+			assertThat(LifecycleTestSub1ViewModel.onViewRemovedCalled).isEqualTo(0);
+			assertThat(LifecycleTestSub2ViewModel.onViewAddedCalled).isEqualTo(1);
+			assertThat(LifecycleTestSub2ViewModel.onViewRemovedCalled).isEqualTo(0);
+
+			// remove from container
+			container.getChildren().clear();
+
+			assertThat(LifecycleTestRootViewModel.onViewAddedCalled).isEqualTo(1);
+			assertThat(LifecycleTestRootViewModel.onViewRemovedCalled).isEqualTo(1);
+			assertThat(LifecycleTestSub1ViewModel.onViewAddedCalled).isEqualTo(1);
+			assertThat(LifecycleTestSub1ViewModel.onViewRemovedCalled).isEqualTo(1);
+			assertThat(LifecycleTestSub2ViewModel.onViewAddedCalled).isEqualTo(1);
+			assertThat(LifecycleTestSub2ViewModel.onViewRemovedCalled).isEqualTo(1);
+
+
+			// add again to container
+			container.getChildren().add(subContainer);
+
+			// the lifecycle methods are invoked again
+			assertThat(LifecycleTestRootViewModel.onViewAddedCalled).isEqualTo(2);
+			assertThat(LifecycleTestRootViewModel.onViewRemovedCalled).isEqualTo(1);
+			assertThat(LifecycleTestSub1ViewModel.onViewAddedCalled).isEqualTo(2);
+			assertThat(LifecycleTestSub1ViewModel.onViewRemovedCalled).isEqualTo(1);
+			assertThat(LifecycleTestSub2ViewModel.onViewAddedCalled).isEqualTo(2);
+			assertThat(LifecycleTestSub2ViewModel.onViewRemovedCalled).isEqualTo(1);
+		});
 	}
 
 
@@ -120,89 +122,91 @@ public class LifecycleTest {
 	 * when the view is added to the scene a second time.
 	 */
 	@Test
-	@TestInJfxThread
 	public void testLifecycleWithSubViewsWithGC() {
-		LifecycleTestRootViewModel.onViewAddedCalled = 0;
-		LifecycleTestRootViewModel.onViewRemovedCalled = 0;
-		LifecycleTestSub1ViewModel.onViewAddedCalled = 0;
-		LifecycleTestSub1ViewModel.onViewRemovedCalled = 0;
-		LifecycleTestSub2ViewModel.onViewAddedCalled = 0;
-		LifecycleTestSub2ViewModel.onViewRemovedCalled = 0;
+		FxTestingUtils.runInFXThread(() -> {
+			LifecycleTestRootViewModel.onViewAddedCalled = 0;
+			LifecycleTestRootViewModel.onViewRemovedCalled = 0;
+			LifecycleTestSub1ViewModel.onViewAddedCalled = 0;
+			LifecycleTestSub1ViewModel.onViewRemovedCalled = 0;
+			LifecycleTestSub2ViewModel.onViewAddedCalled = 0;
+			LifecycleTestSub2ViewModel.onViewRemovedCalled = 0;
 
-		ViewTuple<LifecycleTestRootView, LifecycleTestRootViewModel> viewTuple = FluentViewLoader.fxmlView(LifecycleTestRootView.class).load();
+			ViewTuple<LifecycleTestRootView, LifecycleTestRootViewModel> viewTuple = FluentViewLoader
+					.fxmlView(LifecycleTestRootView.class).load();
 
-		// GC is performed, however as we still have a reference to the viewTuple,
-		// nothing will be collected yet.
-		GCVerifier.forceGC();
+			// GC is performed, however as we still have a reference to the viewTuple,
+			// nothing will be collected yet.
+			GCVerifier.forceGC();
 
-		// the root view is not directly added to the Scene. Instead it is encapsulated in
-		// another container
-		VBox subContainer = new VBox();
-		subContainer.getChildren().add(viewTuple.getView());
+			// the root view is not directly added to the Scene. Instead it is encapsulated in
+			// another container
+			VBox subContainer = new VBox();
+			subContainer.getChildren().add(viewTuple.getView());
 
-		VBox container = new VBox();
+			VBox container = new VBox();
 
-		Stage stage = new Stage();
-		Scene scene = new Scene(container);
-		stage.setScene(scene);
+			Stage stage = new Stage();
+			Scene scene = new Scene(container);
+			stage.setScene(scene);
 
 
-		// now we clear the viewTuple reference ...
-		viewTuple = null;
+			// now we clear the viewTuple reference ...
+			viewTuple = null;
 
-		// and perform GC a second time.
-		// This time, both the ViewModel and the CodeBehind would be collected
-		// if the framework hadn't prevented it.
-		GCVerifier.forceGC();
+			// and perform GC a second time.
+			// This time, both the ViewModel and the CodeBehind would be collected
+			// if the framework hadn't prevented it.
+			GCVerifier.forceGC();
 
-		// before adding to scene
-		assertThat(LifecycleTestRootViewModel.onViewAddedCalled).isEqualTo(0);
-		assertThat(LifecycleTestRootViewModel.onViewRemovedCalled).isEqualTo(0);
-		assertThat(LifecycleTestSub1ViewModel.onViewAddedCalled).isEqualTo(0);
-		assertThat(LifecycleTestSub1ViewModel.onViewRemovedCalled).isEqualTo(0);
-		assertThat(LifecycleTestSub2ViewModel.onViewAddedCalled).isEqualTo(0);
-		assertThat(LifecycleTestSub2ViewModel.onViewRemovedCalled).isEqualTo(0);
+			// before adding to scene
+			assertThat(LifecycleTestRootViewModel.onViewAddedCalled).isEqualTo(0);
+			assertThat(LifecycleTestRootViewModel.onViewRemovedCalled).isEqualTo(0);
+			assertThat(LifecycleTestSub1ViewModel.onViewAddedCalled).isEqualTo(0);
+			assertThat(LifecycleTestSub1ViewModel.onViewRemovedCalled).isEqualTo(0);
+			assertThat(LifecycleTestSub2ViewModel.onViewAddedCalled).isEqualTo(0);
+			assertThat(LifecycleTestSub2ViewModel.onViewRemovedCalled).isEqualTo(0);
 
-		// add rootView to container
-		container.getChildren().add(subContainer);
+			// add rootView to container
+			container.getChildren().add(subContainer);
 
-		// onViewAdded is invoked for all viewModels
-		assertThat(LifecycleTestRootViewModel.onViewAddedCalled).isEqualTo(1);
-		assertThat(LifecycleTestRootViewModel.onViewRemovedCalled).isEqualTo(0);
-		assertThat(LifecycleTestSub1ViewModel.onViewAddedCalled).isEqualTo(1);
-		assertThat(LifecycleTestSub1ViewModel.onViewRemovedCalled).isEqualTo(0);
-		assertThat(LifecycleTestSub2ViewModel.onViewAddedCalled).isEqualTo(1);
-		assertThat(LifecycleTestSub2ViewModel.onViewRemovedCalled).isEqualTo(0);
+			// onViewAdded is invoked for all viewModels
+			assertThat(LifecycleTestRootViewModel.onViewAddedCalled).isEqualTo(1);
+			assertThat(LifecycleTestRootViewModel.onViewRemovedCalled).isEqualTo(0);
+			assertThat(LifecycleTestSub1ViewModel.onViewAddedCalled).isEqualTo(1);
+			assertThat(LifecycleTestSub1ViewModel.onViewRemovedCalled).isEqualTo(0);
+			assertThat(LifecycleTestSub2ViewModel.onViewAddedCalled).isEqualTo(1);
+			assertThat(LifecycleTestSub2ViewModel.onViewRemovedCalled).isEqualTo(0);
 
-		GCVerifier.forceGC();
+			GCVerifier.forceGC();
 
-		// remove from container
-		container.getChildren().clear();
+			// remove from container
+			container.getChildren().clear();
 
-		GCVerifier.forceGC();
+			GCVerifier.forceGC();
 
-		// onViewRemoved is invoked on all ViewModels
-		assertThat(LifecycleTestRootViewModel.onViewAddedCalled).isEqualTo(1);
-		assertThat(LifecycleTestRootViewModel.onViewRemovedCalled).isEqualTo(1);
-		assertThat(LifecycleTestSub1ViewModel.onViewAddedCalled).isEqualTo(1);
-		assertThat(LifecycleTestSub1ViewModel.onViewRemovedCalled).isEqualTo(1);
-		assertThat(LifecycleTestSub2ViewModel.onViewAddedCalled).isEqualTo(1);
-		assertThat(LifecycleTestSub2ViewModel.onViewRemovedCalled).isEqualTo(1);
+			// onViewRemoved is invoked on all ViewModels
+			assertThat(LifecycleTestRootViewModel.onViewAddedCalled).isEqualTo(1);
+			assertThat(LifecycleTestRootViewModel.onViewRemovedCalled).isEqualTo(1);
+			assertThat(LifecycleTestSub1ViewModel.onViewAddedCalled).isEqualTo(1);
+			assertThat(LifecycleTestSub1ViewModel.onViewRemovedCalled).isEqualTo(1);
+			assertThat(LifecycleTestSub2ViewModel.onViewAddedCalled).isEqualTo(1);
+			assertThat(LifecycleTestSub2ViewModel.onViewRemovedCalled).isEqualTo(1);
 
-		// Here the guarantee of the framework ends. This time the viewModels
-		// will be collected
-		GCVerifier.forceGC();
+			// Here the guarantee of the framework ends. This time the viewModels
+			// will be collected
+			GCVerifier.forceGC();
 
-		// add again to container
-		container.getChildren().add(subContainer);
+			// add again to container
+			container.getChildren().add(subContainer);
 
-		// no methods are invoked.
-		assertThat(LifecycleTestRootViewModel.onViewAddedCalled).isEqualTo(1);
-		assertThat(LifecycleTestRootViewModel.onViewRemovedCalled).isEqualTo(1);
-		assertThat(LifecycleTestSub1ViewModel.onViewAddedCalled).isEqualTo(1);
-		assertThat(LifecycleTestSub1ViewModel.onViewRemovedCalled).isEqualTo(1);
-		assertThat(LifecycleTestSub2ViewModel.onViewAddedCalled).isEqualTo(1);
-		assertThat(LifecycleTestSub2ViewModel.onViewRemovedCalled).isEqualTo(1);
+			// no methods are invoked.
+			assertThat(LifecycleTestRootViewModel.onViewAddedCalled).isEqualTo(1);
+			assertThat(LifecycleTestRootViewModel.onViewRemovedCalled).isEqualTo(1);
+			assertThat(LifecycleTestSub1ViewModel.onViewAddedCalled).isEqualTo(1);
+			assertThat(LifecycleTestSub1ViewModel.onViewRemovedCalled).isEqualTo(1);
+			assertThat(LifecycleTestSub2ViewModel.onViewAddedCalled).isEqualTo(1);
+			assertThat(LifecycleTestSub2ViewModel.onViewRemovedCalled).isEqualTo(1);
+		});
 	}
 
 
@@ -217,42 +221,44 @@ public class LifecycleTest {
 	 * prevents Garbage collection.
 	 */
 	@Test
-	@TestInJfxThread
 	public void testGarbageCollectionFailed() {
-		NotificationCenterFactory.setNotificationCenter(new DefaultNotificationCenter());
+		FxTestingUtils.runInFXThread(() -> {
+			NotificationCenterFactory.setNotificationCenter(new DefaultNotificationCenter());
 
-		ViewTuple<NotificationWithoutLifecycleView, NotificationWithoutLifecycleViewModel> viewTuple = FluentViewLoader.fxmlView(NotificationWithoutLifecycleView.class).load();
+			ViewTuple<NotificationWithoutLifecycleView, NotificationWithoutLifecycleViewModel> viewTuple = FluentViewLoader
+					.fxmlView(NotificationWithoutLifecycleView.class).load();
 
-		VBox container = new VBox();
+			VBox container = new VBox();
 
-		Stage stage = new Stage();
-		Scene scene = new Scene(container);
-		stage.setScene(scene);
+			Stage stage = new Stage();
+			Scene scene = new Scene(container);
+			stage.setScene(scene);
 
-		GCVerifier vmVerifier = GCVerifier.create(viewTuple.getViewModel());
+			GCVerifier vmVerifier = GCVerifier.create(viewTuple.getViewModel());
 
-		assertThat(vmVerifier.isAvailableForGC()).isFalse();
+			assertThat(vmVerifier.isAvailableForGC()).isFalse();
 
-		container.getChildren().add(viewTuple.getView());
+			container.getChildren().add(viewTuple.getView());
 
-		viewTuple = null;
+			viewTuple = null;
 
-		// The ViewModel has a listener subscribed so it isn't available for GC
-		assertThat(vmVerifier.isAvailableForGC()).isFalse();
+			// The ViewModel has a listener subscribed so it isn't available for GC
+			assertThat(vmVerifier.isAvailableForGC()).isFalse();
 
-		container.getChildren().clear();
+			container.getChildren().clear();
 
-		// even after the view isn't used anymore, the ViewModel still can't be garbage collected
-		// because it is still registered in the notification center
-		assertThat(vmVerifier.isAvailableForGC()).isFalse();
-
-
-		// only if we replace the notification center ...
-		NotificationCenterFactory.setNotificationCenter(new DefaultNotificationCenter());
+			// even after the view isn't used anymore, the ViewModel still can't be garbage collected
+			// because it is still registered in the notification center
+			assertThat(vmVerifier.isAvailableForGC()).isFalse();
 
 
-		// the viewModel can be garbage collected. Of cause in practice this isn't a suitable solution
-		assertThat(vmVerifier.isAvailableForGC()).isTrue();
+			// only if we replace the notification center ...
+			NotificationCenterFactory.setNotificationCenter(new DefaultNotificationCenter());
+
+
+			// the viewModel can be garbage collected. Of cause in practice this isn't a suitable solution
+			assertThat(vmVerifier.isAvailableForGC()).isTrue();
+		});
 	}
 
 	/**
@@ -266,39 +272,41 @@ public class LifecycleTest {
 	 * Therefore the ViewModel is available for garbage collection afterwards.
 	 */
 	@Test
-	@TestInJfxThread
 	public void testGarbageCollection() {
-		NotificationCenterFactory.setNotificationCenter(new DefaultNotificationCenter());
+		FxTestingUtils.runInFXThread(() -> {
+			NotificationCenterFactory.setNotificationCenter(new DefaultNotificationCenter());
 
-		ViewTuple<LifecycleNotificationView, LifecycleNotificationViewModel> viewTuple = FluentViewLoader.fxmlView(LifecycleNotificationView.class).load();
+			ViewTuple<LifecycleNotificationView, LifecycleNotificationViewModel> viewTuple = FluentViewLoader
+					.fxmlView(LifecycleNotificationView.class).load();
 
-		VBox container = new VBox();
+			VBox container = new VBox();
 
-		Stage stage = new Stage();
-		Scene scene = new Scene(container);
-		stage.setScene(scene);
+			Stage stage = new Stage();
+			Scene scene = new Scene(container);
+			stage.setScene(scene);
 
-		GCVerifier vmVerifier = GCVerifier.create(viewTuple.getViewModel());
+			GCVerifier vmVerifier = GCVerifier.create(viewTuple.getViewModel());
 
-		assertThat(vmVerifier.isAvailableForGC()).isFalse();
+			assertThat(vmVerifier.isAvailableForGC()).isFalse();
 
-		container.getChildren().add(viewTuple.getView());
+			container.getChildren().add(viewTuple.getView());
 
-		viewTuple = null;
+			viewTuple = null;
 
-		// The ViewModel has a listener subscribed so it isn't available for GC now
-		assertThat(vmVerifier.isAvailableForGC()).isFalse();
+			// The ViewModel has a listener subscribed so it isn't available for GC now
+			assertThat(vmVerifier.isAvailableForGC()).isFalse();
 
-		// this triggeres the lifecycle method which is used to deregister the listener
-		container.getChildren().clear();
-
-
-		// therefore the ViewModel can now be garbage collected.
-		assertThat(vmVerifier.isAvailableForGC()).isTrue();
+			// this triggeres the lifecycle method which is used to deregister the listener
+			container.getChildren().clear();
 
 
-		// cleanup notification center to not infer with other tests
-		NotificationCenterFactory.setNotificationCenter(new DefaultNotificationCenter());
+			// therefore the ViewModel can now be garbage collected.
+			assertThat(vmVerifier.isAvailableForGC()).isTrue();
+
+
+			// cleanup notification center to not infer with other tests
+			NotificationCenterFactory.setNotificationCenter(new DefaultNotificationCenter());
+		});
 	}
 
 
@@ -321,40 +329,42 @@ public class LifecycleTest {
 	 * In the previous implementation this resulted in only the first method was invoked.
 	 */
 	@Test
-	@TestInJfxThread
 	public void testGcBetweenLifecycleMethods() {
-		LifecycleGCTestRootViewModel.onViewRemovedCalled = 0;
-		LifecycleGCTestSub1ViewModel.onViewRemovedCalled = 0;
-		LifecycleGCTestSub2ViewModel.onViewRemovedCalled = 0;
+		FxTestingUtils.runInFXThread(() -> {
+			LifecycleGCTestRootViewModel.onViewRemovedCalled = 0;
+			LifecycleGCTestSub1ViewModel.onViewRemovedCalled = 0;
+			LifecycleGCTestSub2ViewModel.onViewRemovedCalled = 0;
 
 
-		ViewTuple<LifecycleGCTestRootView, LifecycleGCTestRootViewModel> viewTuple = FluentViewLoader.fxmlView(LifecycleGCTestRootView.class).load();
+			ViewTuple<LifecycleGCTestRootView, LifecycleGCTestRootViewModel> viewTuple = FluentViewLoader
+					.fxmlView(LifecycleGCTestRootView.class).load();
 
-		VBox subContainer = new VBox();
-		subContainer.getChildren().add(viewTuple.getView());
+			VBox subContainer = new VBox();
+			subContainer.getChildren().add(viewTuple.getView());
 
-		VBox container = new VBox();
+			VBox container = new VBox();
 
-		Stage stage = new Stage();
-		Scene scene = new Scene(container);
-		stage.setScene(scene);
+			Stage stage = new Stage();
+			Scene scene = new Scene(container);
+			stage.setScene(scene);
 
-		viewTuple = null;
+			viewTuple = null;
 
-		GCVerifier.forceGC();
+			GCVerifier.forceGC();
 
-		assertThat(LifecycleGCTestRootViewModel.onViewRemovedCalled).isEqualTo(0);
-		assertThat(LifecycleGCTestSub1ViewModel.onViewRemovedCalled).isEqualTo(0);
-		assertThat(LifecycleGCTestSub2ViewModel.onViewRemovedCalled).isEqualTo(0);
+			assertThat(LifecycleGCTestRootViewModel.onViewRemovedCalled).isEqualTo(0);
+			assertThat(LifecycleGCTestSub1ViewModel.onViewRemovedCalled).isEqualTo(0);
+			assertThat(LifecycleGCTestSub2ViewModel.onViewRemovedCalled).isEqualTo(0);
 
-		container.getChildren().add(subContainer);
+			container.getChildren().add(subContainer);
 
-		GCVerifier.forceGC();
+			GCVerifier.forceGC();
 
-		container.getChildren().remove(subContainer);
+			container.getChildren().remove(subContainer);
 
-		assertThat(LifecycleGCTestRootViewModel.onViewRemovedCalled).isEqualTo(1);
-		assertThat(LifecycleGCTestSub1ViewModel.onViewRemovedCalled).isEqualTo(1);
-		assertThat(LifecycleGCTestSub2ViewModel.onViewRemovedCalled).isEqualTo(1);
+			assertThat(LifecycleGCTestRootViewModel.onViewRemovedCalled).isEqualTo(1);
+			assertThat(LifecycleGCTestSub1ViewModel.onViewRemovedCalled).isEqualTo(1);
+			assertThat(LifecycleGCTestSub2ViewModel.onViewRemovedCalled).isEqualTo(1);
+		});
 	}
 }

--- a/mvvmfx/src/test/java/de/saxsys/mvvmfx/resourcebundle/global/GlobalResourceBundleTest.java
+++ b/mvvmfx/src/test/java/de/saxsys/mvvmfx/resourcebundle/global/GlobalResourceBundleTest.java
@@ -18,11 +18,11 @@ package de.saxsys.mvvmfx.resourcebundle.global;
 import de.saxsys.mvvmfx.FluentViewLoader;
 import de.saxsys.mvvmfx.MvvmFX;
 import de.saxsys.mvvmfx.ViewTuple;
-import de.saxsys.mvvmfx.testingutils.jfxrunner.JfxRunner;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import de.saxsys.mvvmfx.testingutils.JfxToolkitExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.ResourceBundle;
 
@@ -33,21 +33,21 @@ import static org.assertj.core.api.Assertions.assertThat;
  * 
  * @author manuel.mauky
  */
-@RunWith(JfxRunner.class)
+@ExtendWith(JfxToolkitExtension.class)
 public class GlobalResourceBundleTest {
 	
 	
 	private ResourceBundle global;
 	private ResourceBundle other;
 	
-	@Before
+	@BeforeEach
 	public void setup(){
 		MvvmFX.setGlobalResourceBundle(null);
 		global = ResourceBundle.getBundle(this.getClass().getPackage().getName() + ".global");
 		other = ResourceBundle.getBundle(this.getClass().getPackage().getName() + ".other");
 	}
 	
-	@After
+	@AfterEach
 	public void tearDown() {
 		MvvmFX.setGlobalResourceBundle(null);
 	}

--- a/mvvmfx/src/test/java/de/saxsys/mvvmfx/resourcebundle/included/IncludedViewsTest.java
+++ b/mvvmfx/src/test/java/de/saxsys/mvvmfx/resourcebundle/included/IncludedViewsTest.java
@@ -18,11 +18,11 @@ package de.saxsys.mvvmfx.resourcebundle.included;
 import de.saxsys.mvvmfx.FluentViewLoader;
 import de.saxsys.mvvmfx.MvvmFX;
 import de.saxsys.mvvmfx.ViewTuple;
-import de.saxsys.mvvmfx.testingutils.jfxrunner.JfxRunner;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import de.saxsys.mvvmfx.testingutils.JfxToolkitExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.ResourceBundle;
 
@@ -33,21 +33,21 @@ import static org.assertj.core.api.Assertions.assertThat;
  * 
  * @author manuel.mauky
  */
-@RunWith(JfxRunner.class)
+@ExtendWith(JfxToolkitExtension.class)
 public class IncludedViewsTest {
 	
 	
 	private ResourceBundle root;
 	private ResourceBundle included;
 	
-	@Before
+	@BeforeEach
 	public void setup(){
 		MvvmFX.setGlobalResourceBundle(null);
 		root = ResourceBundle.getBundle(this.getClass().getPackage().getName() + ".root");
 		included = ResourceBundle.getBundle(this.getClass().getPackage().getName() + ".included");
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		MvvmFX.setGlobalResourceBundle(null);
 	}

--- a/mvvmfx/src/test/java/de/saxsys/mvvmfx/scopes/context/ContextTest.java
+++ b/mvvmfx/src/test/java/de/saxsys/mvvmfx/scopes/context/ContextTest.java
@@ -3,7 +3,7 @@ package de.saxsys.mvvmfx.scopes.context;
 import de.saxsys.mvvmfx.FluentViewLoader;
 import de.saxsys.mvvmfx.scopes.context.views.ScopedFxmlView;
 import de.saxsys.mvvmfx.scopes.context.views.ScopedFxmlViewModel;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/mvvmfx/src/test/java/de/saxsys/mvvmfx/scopes/example1/Example1ScopesTest.java
+++ b/mvvmfx/src/test/java/de/saxsys/mvvmfx/scopes/example1/Example1ScopesTest.java
@@ -2,8 +2,9 @@ package de.saxsys.mvvmfx.scopes.example1;
 
 import de.saxsys.mvvmfx.FluentViewLoader;
 import de.saxsys.mvvmfx.scopes.example1.views.*;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.omg.SendingContext.RunTime;
 
 public class Example1ScopesTest {
 
@@ -51,64 +52,66 @@ public class Example1ScopesTest {
 		ScopedViewModelG viewModel_B_E_G = parentView.subviewBController.subviewEController.subviewGController.viewModel;
 
 
-		Assert.assertNotNull(viewModel_A_E);
-		Assert.assertNotNull(viewModel_A_E_F);
-		Assert.assertNotNull(viewModel_A_E_G);
-		Assert.assertNotNull(viewModel_B_E);
-		Assert.assertNotNull(viewModel_B_E_F);
-		Assert.assertNotNull(viewModel_B_E_G);
+		Assertions.assertNotNull(viewModel_A_E);
+		Assertions.assertNotNull(viewModel_A_E_F);
+		Assertions.assertNotNull(viewModel_A_E_G);
+		Assertions.assertNotNull(viewModel_B_E);
+		Assertions.assertNotNull(viewModel_B_E_F);
+		Assertions.assertNotNull(viewModel_B_E_G);
 
 
-		Assert.assertNotEquals(viewModel_A_E.testScope3, viewModel_B_E.testScope3);
+		Assertions.assertNotEquals(viewModel_A_E.testScope3, viewModel_B_E.testScope3);
 
-		Assert.assertEquals(viewModel_A_E.testScope3, viewModel_A_E_F.testScope3);
-		Assert.assertEquals(viewModel_A_E.testScope3, viewModel_A_E_G.testScope3);
+		Assertions.assertEquals(viewModel_A_E.testScope3, viewModel_A_E_F.testScope3);
+		Assertions.assertEquals(viewModel_A_E.testScope3, viewModel_A_E_G.testScope3);
 
-		Assert.assertEquals(viewModel_B_E.testScope3, viewModel_B_E_F.testScope3);
-		Assert.assertEquals(viewModel_B_E.testScope3, viewModel_B_E_G.testScope3);
+		Assertions.assertEquals(viewModel_B_E.testScope3, viewModel_B_E_F.testScope3);
+		Assertions.assertEquals(viewModel_B_E.testScope3, viewModel_B_E_G.testScope3);
 
 
 
 		verifyScopes(viewModelA, viewModelB, viewModelCinA, viewModelCinB, viewModelDinA, viewModelDinB);
 	}
 
-	@Test(expected = Exception.class)
+	@Test
 	public void testErrorWhenNoScopeProviderFound() {
 
 		final ScopesFxmlParentView parentView = FluentViewLoader.fxmlView(ScopesFxmlParentView.class)
 				.load()
 				.getCodeBehind();
 
-		parentView.subviewAController.subviewCController.loadWrongScopedView();
+		Assertions.assertThrows(Exception.class, () ->{
+			parentView.subviewAController.subviewCController.loadWrongScopedView();
+		});
 	}
 
 	private void verifyScopes(ScopedViewModelA viewModelA, ScopedViewModelB viewModelB, ScopedViewModelC viewModelCinA,
 							  ScopedViewModelC viewModelCinB, ScopedViewModelD viewModelDinA, ScopedViewModelD viewModelDinB) {
 
-		Assert.assertNotNull(viewModelA);
-		Assert.assertNotNull(viewModelB);
-		Assert.assertNotNull(viewModelCinA);
-		Assert.assertNotNull(viewModelCinB);
-		Assert.assertNotNull(viewModelDinA);
-		Assert.assertNotNull(viewModelDinB);
+		Assertions.assertNotNull(viewModelA);
+		Assertions.assertNotNull(viewModelB);
+		Assertions.assertNotNull(viewModelCinA);
+		Assertions.assertNotNull(viewModelCinB);
+		Assertions.assertNotNull(viewModelDinA);
+		Assertions.assertNotNull(viewModelDinB);
 
-		Assert.assertNotNull(viewModelA.injectedScope1);
-		Assert.assertNotNull(viewModelB.injectedScope1);
-		Assert.assertNotNull(viewModelCinA.injectedScope1);
-		Assert.assertNotNull(viewModelCinB.injectedScope1);
-		Assert.assertNotNull(viewModelDinA.injectedScope1);
-		Assert.assertNotNull(viewModelDinA.injectedScope2);
-		Assert.assertNotNull(viewModelDinB.injectedScope1);
-		Assert.assertNotNull(viewModelDinB.injectedScope2);
+		Assertions.assertNotNull(viewModelA.injectedScope1);
+		Assertions.assertNotNull(viewModelB.injectedScope1);
+		Assertions.assertNotNull(viewModelCinA.injectedScope1);
+		Assertions.assertNotNull(viewModelCinB.injectedScope1);
+		Assertions.assertNotNull(viewModelDinA.injectedScope1);
+		Assertions.assertNotNull(viewModelDinA.injectedScope2);
+		Assertions.assertNotNull(viewModelDinB.injectedScope1);
+		Assertions.assertNotNull(viewModelDinB.injectedScope2);
 
 
-		Assert.assertNotEquals(viewModelA.injectedScope1, viewModelB.injectedScope1);
+		Assertions.assertNotEquals(viewModelA.injectedScope1, viewModelB.injectedScope1);
 
-		Assert.assertEquals(viewModelA.injectedScope1, viewModelCinA.injectedScope1);
-		Assert.assertEquals(viewModelA.injectedScope1, viewModelDinA.injectedScope1);
+		Assertions.assertEquals(viewModelA.injectedScope1, viewModelCinA.injectedScope1);
+		Assertions.assertEquals(viewModelA.injectedScope1, viewModelDinA.injectedScope1);
 
-		Assert.assertEquals(viewModelB.injectedScope1, viewModelCinB.injectedScope1);
-		Assert.assertEquals(viewModelB.injectedScope1, viewModelDinB.injectedScope1);
+		Assertions.assertEquals(viewModelB.injectedScope1, viewModelCinB.injectedScope1);
+		Assertions.assertEquals(viewModelB.injectedScope1, viewModelDinB.injectedScope1);
 
 	}
 

--- a/mvvmfx/src/test/java/de/saxsys/mvvmfx/scopes/example2/Example2ScopesTest.java
+++ b/mvvmfx/src/test/java/de/saxsys/mvvmfx/scopes/example2/Example2ScopesTest.java
@@ -6,14 +6,14 @@ import de.saxsys.mvvmfx.scopes.example2.views.ScopedViewA;
 import de.saxsys.mvvmfx.scopes.example2.views.ScopedViewB;
 import de.saxsys.mvvmfx.scopes.example2.views.ScopedViewC;
 import de.saxsys.mvvmfx.scopes.example2.views.ScopedViewModelA;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 
-@Ignore
+@Disabled
 public class Example2ScopesTest {
 
 	@Test

--- a/mvvmfx/src/test/java/de/saxsys/mvvmfx/scopes/example3/Example3Test.java
+++ b/mvvmfx/src/test/java/de/saxsys/mvvmfx/scopes/example3/Example3Test.java
@@ -4,10 +4,10 @@ import de.saxsys.mvvmfx.FluentViewLoader;
 import de.saxsys.mvvmfx.ViewTuple;
 import de.saxsys.mvvmfx.scopes.example3.views.MainView;
 import de.saxsys.mvvmfx.scopes.example3.views.MainViewModel;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
-@Ignore("Ignore until fixed")
+@Disabled("Ignore until fixed")
 public class Example3Test {
 
 	@Test

--- a/mvvmfx/src/test/java/de/saxsys/mvvmfx/scopes/example4/views/Example4Test.java
+++ b/mvvmfx/src/test/java/de/saxsys/mvvmfx/scopes/example4/views/Example4Test.java
@@ -4,20 +4,14 @@ import com.cedarsoft.test.utils.CatchAllExceptionsRule;
 import de.saxsys.mvvmfx.FluentViewLoader;
 import de.saxsys.mvvmfx.ViewTuple;
 import de.saxsys.mvvmfx.testingutils.FxTestingUtils;
-import de.saxsys.mvvmfx.testingutils.jfxrunner.JfxRunner;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import de.saxsys.mvvmfx.testingutils.JfxToolkitExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(JfxRunner.class)
+@ExtendWith(JfxToolkitExtension.class)
 public class Example4Test {
-
-
-	// Rule to get exceptions from the JavaFX Thread into the JUnit thread
-	@Rule
-	public CatchAllExceptionsRule catchAllExceptionsRule = new CatchAllExceptionsRule();
 
 
 	@Test

--- a/mvvmfx/src/test/java/de/saxsys/mvvmfx/scopes/example5/Example5Test.java
+++ b/mvvmfx/src/test/java/de/saxsys/mvvmfx/scopes/example5/Example5Test.java
@@ -3,12 +3,10 @@ package de.saxsys.mvvmfx.scopes.example5;
 import de.saxsys.mvvmfx.FluentViewLoader;
 import de.saxsys.mvvmfx.ViewTuple;
 import de.saxsys.mvvmfx.testingutils.jfxrunner.JfxRunner;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(JfxRunner.class)
 public class Example5Test {
 
 	@Test

--- a/mvvmfx/src/test/java/de/saxsys/mvvmfx/utils/commands/CommandsWithoutUiThreadTest.java
+++ b/mvvmfx/src/test/java/de/saxsys/mvvmfx/utils/commands/CommandsWithoutUiThreadTest.java
@@ -4,7 +4,7 @@ import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.IntegerProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleIntegerProperty;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.function.Supplier;
 

--- a/mvvmfx/src/test/java/de/saxsys/mvvmfx/utils/commands/CompositeCommandTest.java
+++ b/mvvmfx/src/test/java/de/saxsys/mvvmfx/utils/commands/CompositeCommandTest.java
@@ -23,27 +23,23 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 import com.cedarsoft.test.utils.CatchAllExceptionsRule;
-import de.saxsys.mvvmfx.testingutils.jfxrunner.JfxRunner;
+import de.saxsys.mvvmfx.testingutils.JfxToolkitExtension;
 import javafx.application.Platform;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
 
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import de.saxsys.mvvmfx.testingutils.GCVerifier;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@RunWith(JfxRunner.class)
+@ExtendWith(JfxToolkitExtension.class)
 public class CompositeCommandTest {
 
-	// Rule to get exceptions from the JavaFX Thread into the JUnit thread
-	@Rule
-	public CatchAllExceptionsRule catchAllExceptionsRule = new CatchAllExceptionsRule();
 
 
 	private BooleanProperty condition1;
@@ -53,7 +49,7 @@ public class CompositeCommandTest {
 	private BooleanProperty called2;
 	private DelegateCommand delegateCommand2;
 	
-	@Before
+	@BeforeEach
 	public void init() {
 		condition1 = new SimpleBooleanProperty(true);
 		called1 = new SimpleBooleanProperty();
@@ -170,7 +166,7 @@ public class CompositeCommandTest {
 		compositeCommand.unregister(delegateCommand2);
 	}
 	
-	@Ignore("unstable test. Needs to be fixed. see bug #260")
+	@Disabled("unstable test. Needs to be fixed. see bug #260")
 	@Test
 	public void longRunningAsyncComposite() throws Exception {
 		

--- a/mvvmfx/src/test/java/de/saxsys/mvvmfx/utils/commands/DelegateCommandTest.java
+++ b/mvvmfx/src/test/java/de/saxsys/mvvmfx/utils/commands/DelegateCommandTest.java
@@ -27,9 +27,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import de.saxsys.mvvmfx.testingutils.JfxToolkitExtension;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import com.cedarsoft.test.utils.CatchAllExceptionsRule;
 
@@ -41,15 +41,13 @@ import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.value.ChangeListener;
 import javafx.concurrent.Service;
 import javafx.concurrent.Task;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
 
-@RunWith(JfxRunner.class)
+@ExtendWith(JfxToolkitExtension.class)
 public class DelegateCommandTest {
-	
-	// Rule to get exceptions from the JavaFX Thread into the JUnit thread
-	@Rule
-	public CatchAllExceptionsRule catchAllExceptionsRule = new CatchAllExceptionsRule();
+
 	
 	@Test
 	public void executable() {
@@ -154,7 +152,7 @@ public class DelegateCommandTest {
 				.hasMessage(exceptionReason);
 	}
 	
-	@Test(expected = RuntimeException.class)
+	@Test
 	public void commandNotExecutable() {
 		BooleanProperty condition = new SimpleBooleanProperty(false);
 		
@@ -163,8 +161,10 @@ public class DelegateCommandTest {
 			protected void action() {
 			}
 		}, condition);
-		
-		delegateCommand.execute();
+
+		Assertions.assertThrows(RuntimeException.class, () -> {
+			delegateCommand.execute();
+		});
 	}
 	
 	@Test

--- a/mvvmfx/src/test/java/de/saxsys/mvvmfx/utils/itemlist/ItemListTest.java
+++ b/mvvmfx/src/test/java/de/saxsys/mvvmfx/utils/itemlist/ItemListTest.java
@@ -19,9 +19,9 @@ import javafx.collections.FXCollections;
 import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
 import java.util.List;
@@ -52,7 +52,7 @@ public class ItemListTest {
 	/**
 	 * Prepares the test.
 	 */
-	@Before
+	@BeforeEach
 	public void init() {
 		
 		// Create the items in the model
@@ -77,7 +77,7 @@ public class ItemListTest {
 	 */
 	@Test
 	public void mapFromModelToString() {
-		Assert.assertEquals(PREFIX + PERSON3_NAME, itemList
+		Assertions.assertEquals(PREFIX + PERSON3_NAME, itemList
 				.stringListProperty().get(2));
 	}
 	
@@ -86,11 +86,11 @@ public class ItemListTest {
 	 */
 	@Test
 	public void addItemToItemList() {
-		Assert.assertEquals(3, itemList.stringListProperty().size());
-		Assert.assertEquals(3, listWithModelObjects.size());
+		Assertions.assertEquals(3, itemList.stringListProperty().size());
+		Assertions.assertEquals(3, listWithModelObjects.size());
 		listWithModelObjects.add(new Person("addedPerson"));
-		Assert.assertEquals(4, itemList.stringListProperty().size());
-		Assert.assertEquals(4, listWithModelObjects.size());
+		Assertions.assertEquals(4, itemList.stringListProperty().size());
+		Assertions.assertEquals(4, listWithModelObjects.size());
 	}
 	
 	/**
@@ -98,56 +98,56 @@ public class ItemListTest {
 	 */
 	@Test
 	public void removeItemFromItemList() {
-		Assert.assertEquals(3, itemList.stringListProperty().size());
-		Assert.assertEquals(3, listWithModelObjects.size());
+		Assertions.assertEquals(3, itemList.stringListProperty().size());
+		Assertions.assertEquals(3, listWithModelObjects.size());
 		listWithModelObjects.remove(0);
-		Assert.assertEquals(2, itemList.stringListProperty().size());
-		Assert.assertEquals(2, listWithModelObjects.size());
+		Assertions.assertEquals(2, itemList.stringListProperty().size());
+		Assertions.assertEquals(2, listWithModelObjects.size());
 	}
 	
 	@Test
 	public void removeMultipleItemsFromItemList() {
 		listWithModelObjects.removeAll(person1, person2);
-		Assert.assertEquals(1, listWithModelObjects.size());
-		Assert.assertEquals(1, itemList.stringListProperty().size());
-		Assert.assertEquals(person3, listWithModelObjects.get(0));
-		Assert.assertEquals(PREFIX + PERSON3_NAME, itemList
+		Assertions.assertEquals(1, listWithModelObjects.size());
+		Assertions.assertEquals(1, itemList.stringListProperty().size());
+		Assertions.assertEquals(person3, listWithModelObjects.get(0));
+		Assertions.assertEquals(PREFIX + PERSON3_NAME, itemList
 				.stringListProperty().get(0));
 	}
 	
 	@Test
 	public void removeAllItemsFromItemList() {
 		listWithModelObjects.clear();
-		Assert.assertEquals(0, listWithModelObjects.size());
-		Assert.assertEquals(0, itemList.stringListProperty().size());
+		Assertions.assertEquals(0, listWithModelObjects.size());
+		Assertions.assertEquals(0, itemList.stringListProperty().size());
 	}
 	
 	@Test
 	public void addItemToItemListAtIndex() {
 		listWithModelObjects.add(1, new Person("addedPerson"));
-		Assert.assertEquals(4, itemList.stringListProperty().size());
-		Assert.assertEquals(4, listWithModelObjects.size());
-		Assert.assertEquals(PREFIX + "addedPerson", itemList
+		Assertions.assertEquals(4, itemList.stringListProperty().size());
+		Assertions.assertEquals(4, listWithModelObjects.size());
+		Assertions.assertEquals(PREFIX + "addedPerson", itemList
 				.stringListProperty().get(1));
 	}
 	
 	@Test
 	public void addMultipleItemsToItemList() {
 		listWithModelObjects.addAll(new Person("added1"), new Person("added2"));
-		Assert.assertEquals(5, listWithModelObjects.size());
-		Assert.assertEquals(5, itemList.stringListProperty().size());
-		Assert.assertEquals(PREFIX + "added1", itemList.stringListProperty()
+		Assertions.assertEquals(5, listWithModelObjects.size());
+		Assertions.assertEquals(5, itemList.stringListProperty().size());
+		Assertions.assertEquals(PREFIX + "added1", itemList.stringListProperty()
 				.get(3));
-		Assert.assertEquals(PREFIX + "added2", itemList.stringListProperty()
+		Assertions.assertEquals(PREFIX + "added2", itemList.stringListProperty()
 				.get(4));
 	}
 	
 	@Test
 	public void replaceItemInItemListAtIndex() {
 		listWithModelObjects.set(1, new Person("replacedPerson"));
-		Assert.assertEquals(3, listWithModelObjects.size());
-		Assert.assertEquals(3, itemList.stringListProperty().size());
-		Assert.assertEquals(PREFIX + "replacedPerson", itemList
+		Assertions.assertEquals(3, listWithModelObjects.size());
+		Assertions.assertEquals(3, itemList.stringListProperty().size());
+		Assertions.assertEquals(PREFIX + "replacedPerson", itemList
 				.stringListProperty().get(1));
 	}
 

--- a/mvvmfx/src/test/java/de/saxsys/mvvmfx/utils/itemlist/ListTransformationTest.java
+++ b/mvvmfx/src/test/java/de/saxsys/mvvmfx/utils/itemlist/ListTransformationTest.java
@@ -1,6 +1,6 @@
 package de.saxsys.mvvmfx.utils.itemlist;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/mvvmfx/src/test/java/de/saxsys/mvvmfx/utils/itemlist/SelectableItemListTest.java
+++ b/mvvmfx/src/test/java/de/saxsys/mvvmfx/utils/itemlist/SelectableItemListTest.java
@@ -19,9 +19,9 @@ package de.saxsys.mvvmfx.utils.itemlist;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link SelectableItemList}.
@@ -41,7 +41,7 @@ public class SelectableItemListTest {
 	/**
 	 * Prepares the test.
 	 */
-	@Before
+	@BeforeEach
 	public void init() {
 		
 		// Create the items in the model
@@ -68,8 +68,8 @@ public class SelectableItemListTest {
 	 */
 	@Test
 	public void checkStartState() {
-		Assert.assertEquals(-1, selectableItemList.getSelectedIndex());
-		Assert.assertEquals(null, selectableItemList.getSelectedItem());
+		Assertions.assertEquals(-1, selectableItemList.getSelectedIndex());
+		Assertions.assertEquals(null, selectableItemList.getSelectedItem());
 	}
 	
 	/**
@@ -79,7 +79,7 @@ public class SelectableItemListTest {
 	@Test
 	public void setSelectedItemByIndex() {
 		selectableItemList.select(1);
-		Assert.assertEquals(listWithModelObjects.get(1), selectableItemList
+		Assertions.assertEquals(listWithModelObjects.get(1), selectableItemList
 				.selectedItemProperty().get());
 	}
 	
@@ -90,7 +90,7 @@ public class SelectableItemListTest {
 	@Test
 	public void setSelectedIndexByItem() {
 		selectableItemList.select(person3);
-		Assert.assertEquals(2, selectableItemList.getSelectedIndex());
+		Assertions.assertEquals(2, selectableItemList.getSelectedIndex());
 	}
 	
 	/**
@@ -99,14 +99,14 @@ public class SelectableItemListTest {
 	@Test
 	public void setSelectedIndexWithInvalidItem() {
 		selectableItemList.select(person1);
-		Assert.assertEquals(0, selectableItemList.getSelectedIndex());
-		Assert.assertEquals(person1, selectableItemList.getSelectedItem());
+		Assertions.assertEquals(0, selectableItemList.getSelectedIndex());
+		Assertions.assertEquals(person1, selectableItemList.getSelectedItem());
 		selectableItemList.select(new Person("Roflcopter"));
-		Assert.assertEquals(0, selectableItemList.getSelectedIndex());
-		Assert.assertEquals(person1, selectableItemList.getSelectedItem());
+		Assertions.assertEquals(0, selectableItemList.getSelectedIndex());
+		Assertions.assertEquals(person1, selectableItemList.getSelectedItem());
 		selectableItemList.select(person2);
-		Assert.assertEquals(1, selectableItemList.getSelectedIndex());
-		Assert.assertEquals(person2, selectableItemList.getSelectedItem());
+		Assertions.assertEquals(1, selectableItemList.getSelectedIndex());
+		Assertions.assertEquals(person2, selectableItemList.getSelectedItem());
 	}
 	
 	/**
@@ -115,44 +115,44 @@ public class SelectableItemListTest {
 	@Test
 	public void setSelectedItemWithInvalidIndex() {
 		selectableItemList.select(person1);
-		Assert.assertEquals(0, selectableItemList.getSelectedIndex());
-		Assert.assertEquals(person1, selectableItemList.getSelectedItem());
+		Assertions.assertEquals(0, selectableItemList.getSelectedIndex());
+		Assertions.assertEquals(person1, selectableItemList.getSelectedItem());
 		selectableItemList.select(100);
-		Assert.assertEquals(0, selectableItemList.getSelectedIndex());
-		Assert.assertEquals(person1, selectableItemList.getSelectedItem());
+		Assertions.assertEquals(0, selectableItemList.getSelectedIndex());
+		Assertions.assertEquals(person1, selectableItemList.getSelectedItem());
 	}
 	
 	@Test
 	public void unselectBySettingSelectedItemToNull() {
 		selectableItemList.select(person2);
-		Assert.assertEquals(1, selectableItemList.getSelectedIndex());
-		Assert.assertEquals(person2, selectableItemList.selectedItemProperty()
+		Assertions.assertEquals(1, selectableItemList.getSelectedIndex());
+		Assertions.assertEquals(person2, selectableItemList.selectedItemProperty()
 				.get());
 		selectableItemList.select(null);
-		Assert.assertEquals(-1, selectableItemList.getSelectedIndex());
-		Assert.assertNull(selectableItemList.selectedItemProperty().get());
+		Assertions.assertEquals(-1, selectableItemList.getSelectedIndex());
+		Assertions.assertNull(selectableItemList.selectedItemProperty().get());
 	}
 	
 	@Test
 	public void unselectBySettingSelectedIndexToMinus1() {
 		selectableItemList.select(person2);
-		Assert.assertEquals(1, selectableItemList.getSelectedIndex());
-		Assert.assertEquals(person2, selectableItemList.selectedItemProperty()
+		Assertions.assertEquals(1, selectableItemList.getSelectedIndex());
+		Assertions.assertEquals(person2, selectableItemList.selectedItemProperty()
 				.get());
 		selectableItemList.select(-1);
-		Assert.assertEquals(-1, selectableItemList.getSelectedIndex());
-		Assert.assertNull(selectableItemList.selectedItemProperty().get());
+		Assertions.assertEquals(-1, selectableItemList.getSelectedIndex());
+		Assertions.assertNull(selectableItemList.selectedItemProperty().get());
 	}
 	
 	@Test
 	public void unselectByClearSelection() {
 		selectableItemList.select(person2);
-		Assert.assertEquals(1, selectableItemList.getSelectedIndex());
-		Assert.assertEquals(person2, selectableItemList.selectedItemProperty()
+		Assertions.assertEquals(1, selectableItemList.getSelectedIndex());
+		Assertions.assertEquals(person2, selectableItemList.selectedItemProperty()
 				.get());
 		selectableItemList.clearSelection();
-		Assert.assertEquals(-1, selectableItemList.getSelectedIndex());
-		Assert.assertNull(selectableItemList.selectedItemProperty().get());
+		Assertions.assertEquals(-1, selectableItemList.getSelectedIndex());
+		Assertions.assertNull(selectableItemList.selectedItemProperty().get());
 	}
 	
 }

--- a/mvvmfx/src/test/java/de/saxsys/mvvmfx/utils/mapping/FieldMethodOverloadingTest.java
+++ b/mvvmfx/src/test/java/de/saxsys/mvvmfx/utils/mapping/FieldMethodOverloadingTest.java
@@ -24,8 +24,8 @@ import javafx.beans.property.LongProperty;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.Property;
 import javafx.beans.property.StringProperty;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -59,7 +59,7 @@ public class FieldMethodOverloadingTest {
 	
 	private ModelWrapper<ExampleModel> wrapper;
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		wrapper = new ModelWrapper<>();
 	}

--- a/mvvmfx/src/test/java/de/saxsys/mvvmfx/utils/mapping/ModelWrapperTest.java
+++ b/mvvmfx/src/test/java/de/saxsys/mvvmfx/utils/mapping/ModelWrapperTest.java
@@ -20,7 +20,7 @@ import javafx.beans.property.ListProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.property.StringProperty;
 import javafx.collections.FXCollections;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/mvvmfx/src/test/java/de/saxsys/mvvmfx/utils/notifications/ConcurrentModificationBugTest.java
+++ b/mvvmfx/src/test/java/de/saxsys/mvvmfx/utils/notifications/ConcurrentModificationBugTest.java
@@ -15,7 +15,7 @@
  ******************************************************************************/
 package de.saxsys.mvvmfx.utils.notifications;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 
 /**

--- a/mvvmfx/src/test/java/de/saxsys/mvvmfx/utils/notifications/DefaultNotificationCenterTest.java
+++ b/mvvmfx/src/test/java/de/saxsys/mvvmfx/utils/notifications/DefaultNotificationCenterTest.java
@@ -17,11 +17,12 @@
 package de.saxsys.mvvmfx.utils.notifications;
 
 import de.saxsys.mvvmfx.ViewModel;
-import de.saxsys.mvvmfx.testingutils.jfxrunner.JfxRunner;
+import de.saxsys.mvvmfx.testingutils.JfxToolkitExtension;
 import javafx.application.Platform;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 
 import java.util.concurrent.CompletableFuture;
@@ -31,7 +32,7 @@ import java.util.concurrent.TimeoutException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(JfxRunner.class)
+@ExtendWith(JfxToolkitExtension.class)
 public class DefaultNotificationCenterTest {
 	
 	private static final String TEST_NOTIFICATION = "test_notification";
@@ -44,7 +45,7 @@ public class DefaultNotificationCenterTest {
 	NotificationObserver observer2;
 	NotificationObserver observer3;
 	
-	@Before
+	@BeforeEach
 	public void init() {
 		observer1 = Mockito.mock(NotificationObserver.class);
 		observer2 = Mockito.mock(NotificationObserver.class);
@@ -178,8 +179,10 @@ public class DefaultNotificationCenterTest {
 		assertThat(wasCalledOnUiThread).isTrue();
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void subscribeWithNullObserver() {
-		defaultCenter.subscribe(TEST_NOTIFICATION,null);
+		Assertions.assertThrows(IllegalArgumentException.class, () -> {
+			defaultCenter.subscribe(TEST_NOTIFICATION, null);
+		});
 	}
 }

--- a/mvvmfx/src/test/java/de/saxsys/mvvmfx/utils/notifications/MemoryLeakGlobalTest.java
+++ b/mvvmfx/src/test/java/de/saxsys/mvvmfx/utils/notifications/MemoryLeakGlobalTest.java
@@ -1,8 +1,8 @@
 package de.saxsys.mvvmfx.utils.notifications;
 
 import de.saxsys.mvvmfx.testingutils.GCVerifier;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -16,7 +16,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class MemoryLeakGlobalTest {
 
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		NotificationCenterFactory.setNotificationCenter(new DefaultNotificationCenter());
 	}

--- a/mvvmfx/src/test/java/de/saxsys/mvvmfx/utils/notifications/NotificationTestHelperTest.java
+++ b/mvvmfx/src/test/java/de/saxsys/mvvmfx/utils/notifications/NotificationTestHelperTest.java
@@ -17,8 +17,8 @@ package de.saxsys.mvvmfx.utils.notifications;
 
 import de.saxsys.mvvmfx.ViewModel;
 import javafx.util.Pair;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.stream.Stream;
 
@@ -34,7 +34,7 @@ public class NotificationTestHelperTest {
 	
 	private MyViewModel viewModel;
 	
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		viewModel = new MyViewModel();
 	}

--- a/mvvmfx/src/test/java/de/saxsys/mvvmfx/utils/notifications/ResetNotificationCenterTest.java
+++ b/mvvmfx/src/test/java/de/saxsys/mvvmfx/utils/notifications/ResetNotificationCenterTest.java
@@ -15,9 +15,9 @@
  ******************************************************************************/
 package de.saxsys.mvvmfx.utils.notifications;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -40,7 +40,7 @@ public class ResetNotificationCenterTest {
     private static final String MY_MESSAGE = "myMessage";
     private AtomicBoolean wasCalled = new AtomicBoolean(false);
 
-    @Before
+    @BeforeEach
     public void setup() {
         NotificationCenter notificationCenter = NotificationCenterFactory.getNotificationCenter();
 
@@ -59,7 +59,7 @@ public class ResetNotificationCenterTest {
      * one of the test cases would fail.
      * By replacing the instance we assure that each test uses a fresh notification center.
      */
-    @After
+    @AfterEach
     public void tearDown() {
 
         NotificationCenterFactory.setNotificationCenter(new DefaultNotificationCenter());

--- a/mvvmfx/src/test/java/de/saxsys/mvvmfx/utils/notifications/viewmodel/MemoryLeakOnViewModelTest.java
+++ b/mvvmfx/src/test/java/de/saxsys/mvvmfx/utils/notifications/viewmodel/MemoryLeakOnViewModelTest.java
@@ -1,12 +1,13 @@
 package de.saxsys.mvvmfx.utils.notifications.viewmodel;
 
 import de.saxsys.mvvmfx.ViewModel;
+import de.saxsys.mvvmfx.testingutils.FxTestingUtils;
 import de.saxsys.mvvmfx.testingutils.GCVerifier;
-import de.saxsys.mvvmfx.testingutils.jfxrunner.JfxRunner;
+import de.saxsys.mvvmfx.testingutils.JfxToolkitExtension;
 import de.saxsys.mvvmfx.utils.notifications.NotificationObserver;
 import javafx.application.Platform;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -21,7 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * This test verifies that the communication between View and ViewModel
  * via notifications doesn't introduce memory leaks.
  */
-@RunWith(JfxRunner.class)
+@ExtendWith(JfxToolkitExtension.class)
 public class MemoryLeakOnViewModelTest {
 
 
@@ -43,7 +44,7 @@ public class MemoryLeakOnViewModelTest {
 
 		viewModel.actionThatPublishes();
 
-		waitForUiThread();
+		FxTestingUtils.waitForUiThread();
 
 
 		assertThat(view.counter.get()).isEqualTo(1);
@@ -79,7 +80,7 @@ public class MemoryLeakOnViewModelTest {
 		vm.publish("test");
 
 
-		waitForUiThread();
+		FxTestingUtils.waitForUiThread();
 
 
 		assertThat(counter.get()).isEqualTo(1);
@@ -115,7 +116,7 @@ public class MemoryLeakOnViewModelTest {
 
 		vm.publish("test");
 
-		waitForUiThread();
+		FxTestingUtils.waitForUiThread();
 
 		assertThat(StaticObserver.counter.get()).isEqualTo(1);
 
@@ -136,21 +137,6 @@ public class MemoryLeakOnViewModelTest {
 		@Override
 		public void receivedNotification(String key, Object... payload) {
 			StaticObserver.counter.incrementAndGet();
-		}
-	}
-
-
-	/**
-	 * This method is used to wait until the UI thread has done all work that was queued via
-	 * {@link Platform#runLater(Runnable)}.
-	 */
-	private void waitForUiThread() {
-		CompletableFuture<Void> future = new CompletableFuture<>();
-		Platform.runLater(() -> future.complete(null));
-		try {
-			future.get(1l, TimeUnit.SECONDS);
-		} catch (InterruptedException | ExecutionException | TimeoutException e) {
-			throw new IllegalStateException(e);
 		}
 	}
 

--- a/mvvmfx/src/test/java/de/saxsys/mvvmfx/utils/notifications/viewmodel/ViewModelTest.java
+++ b/mvvmfx/src/test/java/de/saxsys/mvvmfx/utils/notifications/viewmodel/ViewModelTest.java
@@ -17,15 +17,16 @@ package de.saxsys.mvvmfx.utils.notifications.viewmodel;
 
 import de.saxsys.mvvmfx.MvvmFX;
 import de.saxsys.mvvmfx.ViewModel;
-import de.saxsys.mvvmfx.testingutils.jfxrunner.JfxRunner;
+import de.saxsys.mvvmfx.testingutils.FxTestingUtils;
+import de.saxsys.mvvmfx.testingutils.JfxToolkitExtension;
 import de.saxsys.mvvmfx.utils.notifications.DefaultNotificationCenter;
 import de.saxsys.mvvmfx.utils.notifications.DefaultNotificationCenterTest;
 import de.saxsys.mvvmfx.utils.notifications.NotificationCenterFactory;
 import de.saxsys.mvvmfx.utils.notifications.NotificationObserver;
 import javafx.application.Platform;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 
 import java.util.concurrent.CompletableFuture;
@@ -36,7 +37,7 @@ import java.util.concurrent.TimeoutException;
 /**
  * This test verifies the communication via notifications between the View and ViewModel.
  */
-@RunWith(JfxRunner.class)
+@ExtendWith(JfxToolkitExtension.class)
 public class ViewModelTest {
 	
 	private static final String TEST_NOTIFICATION = "test_notification";
@@ -47,7 +48,7 @@ public class ViewModelTest {
 	DummyNotificationObserver observer2;
 	DummyNotificationObserver observer3;
 	
-	@Before
+	@BeforeEach
 	public void init() {
 		observer1 = Mockito.mock(DummyNotificationObserver.class);
 		observer2 = Mockito.mock(DummyNotificationObserver.class);
@@ -63,7 +64,7 @@ public class ViewModelTest {
 		MvvmFX.getNotificationCenter().subscribe(TEST_NOTIFICATION, observer1);
 		viewModel.publish(TEST_NOTIFICATION);
 		
-		waitForUiThread();
+		FxTestingUtils.waitForUiThread();
 		Mockito.verify(observer1, Mockito.never()).receivedNotification(TEST_NOTIFICATION);
 	}
 	
@@ -72,7 +73,7 @@ public class ViewModelTest {
 		viewModel.subscribe(TEST_NOTIFICATION, observer1);
 		viewModel.publish(TEST_NOTIFICATION, OBJECT_ARRAY_FOR_NOTIFICATION);
 		
-		waitForUiThread();
+		FxTestingUtils.waitForUiThread();
 		Mockito.verify(observer1).receivedNotification(TEST_NOTIFICATION, OBJECT_ARRAY_FOR_NOTIFICATION);
 	}
 	
@@ -82,14 +83,14 @@ public class ViewModelTest {
 		viewModel.unsubscribe(observer1);
 		viewModel.publish(TEST_NOTIFICATION);
 		
-		waitForUiThread();
+		FxTestingUtils.waitForUiThread();
 		Mockito.verify(observer1, Mockito.never()).receivedNotification(TEST_NOTIFICATION);
 		
 		viewModel.subscribe(TEST_NOTIFICATION, observer1);
 		viewModel.unsubscribe(TEST_NOTIFICATION, observer1);
 		viewModel.publish(TEST_NOTIFICATION);
 		
-		waitForUiThread();
+		FxTestingUtils.waitForUiThread();
 		Mockito.verify(observer1, Mockito.never()).receivedNotification(TEST_NOTIFICATION);
 	}
 	
@@ -100,7 +101,7 @@ public class ViewModelTest {
 		viewModel.subscribe(TEST_NOTIFICATION, observer3);
 		viewModel.publish(TEST_NOTIFICATION, OBJECT_ARRAY_FOR_NOTIFICATION);
 		
-		waitForUiThread();
+		FxTestingUtils.waitForUiThread();
 		
 		Mockito.verify(observer1).receivedNotification(TEST_NOTIFICATION, OBJECT_ARRAY_FOR_NOTIFICATION);
 		Mockito.verify(observer2).receivedNotification(TEST_NOTIFICATION, OBJECT_ARRAY_FOR_NOTIFICATION);
@@ -116,7 +117,7 @@ public class ViewModelTest {
 		viewModel.unsubscribe(observer1);
 		viewModel.publish(TEST_NOTIFICATION, OBJECT_ARRAY_FOR_NOTIFICATION);
 		
-		waitForUiThread();
+		FxTestingUtils.waitForUiThread();
 		
 		Mockito.verify(observer1, Mockito.never()).receivedNotification(TEST_NOTIFICATION,
 				OBJECT_ARRAY_FOR_NOTIFICATION);
@@ -136,20 +137,7 @@ public class ViewModelTest {
 		
 		viewModel.unsubscribe(TEST_NOTIFICATION, observer1);
 	}
-	
-	/**
-	 * This method is used to wait until the UI thread has done all work that was queued via
-	 * {@link Platform#runLater(Runnable)}.
-	 */
-	private void waitForUiThread() {
-		CompletableFuture<Void> future = new CompletableFuture<>();
-		Platform.runLater(() -> future.complete(null));
-		try {
-			future.get(1l, TimeUnit.SECONDS);
-		} catch (InterruptedException | ExecutionException | TimeoutException e) {
-			throw new IllegalStateException(e);
-		}
-	}
+
 	
 	private class DummyNotificationObserver implements NotificationObserver {
 		@Override

--- a/mvvmfx/src/test/java/de/saxsys/mvvmfx/utils/notifications/viewmodel/ViewModelWithoutUiThreadTest.java
+++ b/mvvmfx/src/test/java/de/saxsys/mvvmfx/utils/notifications/viewmodel/ViewModelWithoutUiThreadTest.java
@@ -16,7 +16,7 @@
 package de.saxsys.mvvmfx.utils.notifications.viewmodel;
 
 import de.saxsys.mvvmfx.ViewModel;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;

--- a/mvvmfx/src/test/java/de/saxsys/mvvmfx/utils/notifications/viewmodel/WeakNotificationsTest.java
+++ b/mvvmfx/src/test/java/de/saxsys/mvvmfx/utils/notifications/viewmodel/WeakNotificationsTest.java
@@ -1,10 +1,8 @@
 package de.saxsys.mvvmfx.utils.notifications.viewmodel;
 
-import de.saxsys.mvvmfx.testingutils.jfxrunner.JfxRunner;
 import de.saxsys.mvvmfx.utils.notifications.*;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 /**
@@ -12,7 +10,6 @@ import org.mockito.Mockito;
  * To do this most test cases of {@link DefaultNotificationCenterTest}
  * are reproduced with the weak variant of notifications.
  */
-@RunWith(JfxRunner.class)
 public class WeakNotificationsTest {
 
 
@@ -26,7 +23,7 @@ public class WeakNotificationsTest {
 	NotificationObserver observer2;
 	NotificationObserver observer3;
 
-	@Before
+	@BeforeEach
 	public void init() {
 		observer1 = Mockito.mock(NotificationObserver.class);
 		observer2 = Mockito.mock(NotificationObserver.class);

--- a/pom.xml
+++ b/pom.xml
@@ -275,6 +275,29 @@
 				<artifactId>maven-gpg-plugin</artifactId>
 				<version>1.1</version>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<!-- Minimal supported version is 2.4 -->
+				<version>2.19.1</version>
+				<dependencies>
+					<dependency>
+						<groupId>org.junit.platform</groupId>
+						<artifactId>junit-platform-surefire-provider</artifactId>
+						<version>1.0.0-RC2</version>
+					</dependency>
+					<dependency>
+						<groupId>org.junit.jupiter</groupId>
+						<artifactId>junit-jupiter-engine</artifactId>
+						<version>5.0.0-RC2</version>
+					</dependency>
+					<dependency>
+						<groupId>org.junit.vintage</groupId>
+						<artifactId>junit-vintage-engine</artifactId>
+						<version>4.12.0-RC2</version>
+					</dependency>
+				</dependencies>
+			</plugin>
 		</plugins>
 	</build>
 	<profiles>
@@ -326,7 +349,7 @@
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-surefire-plugin</artifactId>
 						<!-- Minimal supported version is 2.4 -->
-						<version>2.16</version>
+						<version>2.19.1</version>
 						<configuration>
 							<properties>
 								<property>
@@ -335,6 +358,23 @@
 								</property>
 							</properties>
 						</configuration>
+						<dependencies>
+							<dependency>
+								<groupId>org.junit.platform</groupId>
+								<artifactId>junit-platform-surefire-provider</artifactId>
+								<version>1.0.0-RC2</version>
+							</dependency>
+							<dependency>
+								<groupId>org.junit.jupiter</groupId>
+								<artifactId>junit-jupiter-engine</artifactId>
+								<version>5.0.0-RC2</version>
+							</dependency>
+							<dependency>
+								<groupId>org.junit.vintage</groupId>
+								<artifactId>junit-vintage-engine</artifactId>
+								<version>4.12.0-RC2</version>
+							</dependency>
+						</dependencies>
 					</plugin>
 				</plugins>
 			</build>

--- a/pom.xml
+++ b/pom.xml
@@ -184,6 +184,11 @@
 				<version>4.12</version>
 			</dependency>
 			<dependency>
+				<groupId>org.junit.jupiter</groupId>
+				<artifactId>junit-jupiter-api</artifactId>
+				<version>5.0.0-RC2</version>
+			</dependency>
+			<dependency>
 				<groupId>org.mockito</groupId>
 				<artifactId>mockito-all</artifactId>
 				<version>1.10.19</version>


### PR DESCRIPTION
#503 

JfxRunner (#504) was replaced by JfxToolkitExtension, which initializes the JavaFX Toolkit before all tests are made, and a method on FxTestingUtils (runInFXThread), which runs a code block on Platform.runLater()

BooksExampleIT from books-example and IntegrationTestWithTestFX from fx-root-example have a dependency on junit4. They both use GuiTest from TestFX-legacy, which uses junit4 on the background.