### PR TITLE
498 throw exception viewmodel as controller

### DIFF
--- a/mvvmfx/src/main/java/de/saxsys/mvvmfx/internal/viewloader/FxmlViewLoader.java
+++ b/mvvmfx/src/main/java/de/saxsys/mvvmfx/internal/viewloader/FxmlViewLoader.java
@@ -284,10 +284,8 @@ public class FxmlViewLoader {
             Object controller = DependencyInjector.getInstance().getInstanceOf(type);
 
             //throw an exception if the fx:controller was of type ViewModel
-//            Object controller = loader.getController();
             if (controller instanceof ViewModel) {
-                throw new IllegalStateException("A ViewModel class [" + controller.getClass().getCanonicalName() + "] was referenced in the FXML file"
-//                        + "["+resource+"]"
+                throw new IllegalStateException("A ViewModel class [" + controller.getClass().getCanonicalName() + "] was referenced in an FXML file"
                         + " as the fx:controller."
                         + " Instead a class that implements FxmlView has to be defined as the fx:controller in the FXML file.");
             }
@@ -402,10 +400,8 @@ public class FxmlViewLoader {
             }
 
             //throw an exception if the fx:controller was of type ViewModel
-            //            Object controller = loader.getController();
             if (controller instanceof ViewModel) {
-                throw new IllegalStateException("A ViewModel class [" + controller.getClass().getCanonicalName() + "] was referenced in the FXML file"
-                        //                        + "["+resource+"]"
+                throw new IllegalStateException("A ViewModel class [" + controller.getClass().getCanonicalName() + "] was referenced an the FXML file"
                         + " as the fx:controller."
                         + " Instead a class that implements FxmlView has to be defined as the fx:controller in the FXML file.");
             }

--- a/mvvmfx/src/main/java/de/saxsys/mvvmfx/internal/viewloader/FxmlViewLoader.java
+++ b/mvvmfx/src/main/java/de/saxsys/mvvmfx/internal/viewloader/FxmlViewLoader.java
@@ -401,7 +401,7 @@ public class FxmlViewLoader {
 
             //throw an exception if the fx:controller was of type ViewModel
             if (controller instanceof ViewModel) {
-                throw new IllegalStateException("A ViewModel class [" + controller.getClass().getCanonicalName() + "] was referenced an the FXML file"
+                throw new IllegalStateException("A ViewModel class [" + controller.getClass().getCanonicalName() + "] was referenced in an FXML file"
                         + " as the fx:controller."
                         + " Instead a class that implements FxmlView has to be defined as the fx:controller in the FXML file.");
             }

--- a/mvvmfx/src/main/java/de/saxsys/mvvmfx/internal/viewloader/FxmlViewLoader.java
+++ b/mvvmfx/src/main/java/de/saxsys/mvvmfx/internal/viewloader/FxmlViewLoader.java
@@ -164,6 +164,13 @@ public class FxmlViewLoader {
 
             loader.load();
 
+            //throw an exception if the fx:controller was of type ViewModel
+            Object controller = loader.getController();
+            if (controller instanceof ViewModel) {
+                throw new IllegalStateException("A ViewModel class [" + controller.getClass().getCanonicalName() + "] was referenced in the FXML file ["+resource+"] as the fx:controller."
+                        + " Instead a class that implements FxmlView has to be defined as the fx:controller in the FXML file.");
+            }
+
             final ViewType loadedController = loader.getController();
             final Parent loadedRoot = loader.getRoot();
 

--- a/mvvmfx/src/main/java/de/saxsys/mvvmfx/internal/viewloader/FxmlViewLoader.java
+++ b/mvvmfx/src/main/java/de/saxsys/mvvmfx/internal/viewloader/FxmlViewLoader.java
@@ -164,13 +164,6 @@ public class FxmlViewLoader {
 
             loader.load();
 
-            //throw an exception if the fx:controller was of type ViewModel
-            Object controller = loader.getController();
-            if (controller instanceof ViewModel) {
-                throw new IllegalStateException("A ViewModel class [" + controller.getClass().getCanonicalName() + "] was referenced in the FXML file ["+resource+"] as the fx:controller."
-                        + " Instead a class that implements FxmlView has to be defined as the fx:controller in the FXML file.");
-            }
-
             final ViewType loadedController = loader.getController();
             final Parent loadedRoot = loader.getRoot();
 
@@ -290,6 +283,15 @@ public class FxmlViewLoader {
         public Object call(Class<?> type) {
             Object controller = DependencyInjector.getInstance().getInstanceOf(type);
 
+            //throw an exception if the fx:controller was of type ViewModel
+//            Object controller = loader.getController();
+            if (controller instanceof ViewModel) {
+                throw new IllegalStateException("A ViewModel class [" + controller.getClass().getCanonicalName() + "] was referenced in the FXML file"
+//                        + "["+resource+"]"
+                        + " as the fx:controller."
+                        + " Instead a class that implements FxmlView has to be defined as the fx:controller in the FXML file.");
+            }
+
             if (controller instanceof View) {
                 View codeBehind = (View) controller;
 
@@ -398,6 +400,16 @@ public class FxmlViewLoader {
 
                 handleInjection(codeBehind, resourceBundle, context, viewInSceneProperty);
             }
+
+            //throw an exception if the fx:controller was of type ViewModel
+            //            Object controller = loader.getController();
+            if (controller instanceof ViewModel) {
+                throw new IllegalStateException("A ViewModel class [" + controller.getClass().getCanonicalName() + "] was referenced in the FXML file"
+                        //                        + "["+resource+"]"
+                        + " as the fx:controller."
+                        + " Instead a class that implements FxmlView has to be defined as the fx:controller in the FXML file.");
+            }
+
 
             return controller;
         }

--- a/mvvmfx/src/test/java/de/saxsys/mvvmfx/internal/viewloader/FluentViewLoader_FxmlView_Test.java
+++ b/mvvmfx/src/test/java/de/saxsys/mvvmfx/internal/viewloader/FluentViewLoader_FxmlView_Test.java
@@ -535,10 +535,10 @@ public class FluentViewLoader_FxmlView_Test {
 					.load();
 		} catch (RuntimeException e){
 			assertThat(ExceptionUtils.getRootCause(e)).isInstanceOf(IllegalStateException.class);
-			assertThat(ExceptionUtils.getRootCause(e).getMessage())
-					.contains("A ViewModel class")
-					.contains("was referenced in an FXML file")
-					.contains("as the fx:controller");
+			assertThat(ExceptionUtils.getRootCause(e))
+					.hasMessageContaining("A ViewModel class")
+					.hasMessageContaining("was referenced in an FXML file")
+					.hasMessageContaining("as the fx:controller");
 		}
 
 		//with ControllerFactoryWithCustomViewModel
@@ -548,10 +548,10 @@ public class FluentViewLoader_FxmlView_Test {
 					.load();
 		} catch (RuntimeException e){
 			assertThat(ExceptionUtils.getRootCause(e)).isInstanceOf(IllegalStateException.class);
-			assertThat(ExceptionUtils.getRootCause(e).getMessage())
-					.contains("A ViewModel class")
-					.contains("was referenced in an FXML file")
-					.contains("as the fx:controller");
+			assertThat(ExceptionUtils.getRootCause(e))
+					.hasMessageContaining("A ViewModel class")
+					.hasMessageContaining("was referenced in an FXML file")
+					.hasMessageContaining("as the fx:controller");
 		}
 	}
 
@@ -562,10 +562,10 @@ public class FluentViewLoader_FxmlView_Test {
 					.load();
 		} catch (RuntimeException e){
 			assertThat(ExceptionUtils.getRootCause(e)).isInstanceOf(IllegalStateException.class);
-			assertThat(ExceptionUtils.getRootCause(e).getMessage())
-					.contains("A ViewModel class")
-					.contains("was referenced in the FXML file")
-					.contains("as the fx:controller");
+			assertThat(ExceptionUtils.getRootCause(e))
+					.hasMessageContaining("A ViewModel class")
+					.hasMessageContaining("was referenced in the FXML file")
+					.hasMessageContaining("as the fx:controller");
 		}
 
 		//with ControllerFactoryWithCustomViewModel
@@ -575,10 +575,10 @@ public class FluentViewLoader_FxmlView_Test {
 					.load();
 		} catch (RuntimeException e){
 			assertThat(ExceptionUtils.getRootCause(e)).isInstanceOf(IllegalStateException.class);
-			assertThat(ExceptionUtils.getRootCause(e).getMessage())
-					.contains("A ViewModel class")
-					.contains("was referenced in the FXML file")
-					.contains("as the fx:controller");
+			assertThat(ExceptionUtils.getRootCause(e))
+					.hasMessageContaining("A ViewModel class")
+					.hasMessageContaining("was referenced in the FXML file")
+					.hasMessageContaining("as the fx:controller");
 		}
 
 	}

--- a/mvvmfx/src/test/java/de/saxsys/mvvmfx/internal/viewloader/FluentViewLoader_FxmlView_Test.java
+++ b/mvvmfx/src/test/java/de/saxsys/mvvmfx/internal/viewloader/FluentViewLoader_FxmlView_Test.java
@@ -527,4 +527,24 @@ public class FluentViewLoader_FxmlView_Test {
 		assertThat(TestViewModel.instanceCounter).isEqualTo(1);
 		assertThat(TestViewModel.wasInitialized).isTrue();
 	}
+
+	@Test
+	public void testFxmlViewModelAsControllerException(){
+		try {
+			ViewTuple<TestFxmlViewModelAsController, TestFxmlViewModelAsControllerViewModel> load = FluentViewLoader
+					.fxmlView(TestFxmlViewModelAsController.class).load();
+		} catch (IllegalStateException e){
+			assertThat(e.getMessage()).contains("A ViewModel class").contains("was referenced in the FXML file").contains("as the fx:controller");
+		}
+	}
+
+	@Test
+	public void testFxmlViewModelAsControllerWithCustomPath(){
+		ViewTuple<TestFxmlViewModelAsControllerWithCustomPath, TestFxmlViewModelAsControllerWithCustomPathViewModel> load = FluentViewLoader
+				.fxmlView(TestFxmlViewModelAsControllerWithCustomPath.class).load();
+
+		//should work since the View points to another FXML through @FxmlPath
+		assertThat(load.getView()).isNotNull().isInstanceOf(VBox.class);
+		System.out.println("test");
+	}
 }

--- a/mvvmfx/src/test/java/de/saxsys/mvvmfx/internal/viewloader/FluentViewLoader_FxmlView_Test.java
+++ b/mvvmfx/src/test/java/de/saxsys/mvvmfx/internal/viewloader/FluentViewLoader_FxmlView_Test.java
@@ -533,10 +533,11 @@ public class FluentViewLoader_FxmlView_Test {
 		try {
 			FluentViewLoader.fxmlView(TestFxmlViewModelAsController.class)
 					.load();
-		} catch (RuntimeException e){ ;
-			assertThat(e.getCause().getCause().getMessage())
+		} catch (RuntimeException e){
+			assertThat(ExceptionUtils.getRootCause(e)).isInstanceOf(IllegalStateException.class);
+			assertThat(ExceptionUtils.getRootCause(e).getMessage())
 					.contains("A ViewModel class")
-					.contains("was referenced in the FXML file")
+					.contains("was referenced in an FXML file")
 					.contains("as the fx:controller");
 		}
 
@@ -545,10 +546,11 @@ public class FluentViewLoader_FxmlView_Test {
 			FluentViewLoader.fxmlView(TestFxmlViewModelAsController.class)
 					.viewModel(new TestFxmlViewModelAsControllerViewModel())
 					.load();
-		} catch (RuntimeException e){ ;
-			assertThat(e.getCause().getCause().getMessage())
+		} catch (RuntimeException e){
+			assertThat(ExceptionUtils.getRootCause(e)).isInstanceOf(IllegalStateException.class);
+			assertThat(ExceptionUtils.getRootCause(e).getMessage())
 					.contains("A ViewModel class")
-					.contains("was referenced in the FXML file")
+					.contains("was referenced in an FXML file")
 					.contains("as the fx:controller");
 		}
 	}
@@ -559,7 +561,8 @@ public class FluentViewLoader_FxmlView_Test {
 			FluentViewLoader.fxmlView(TestFxmlViewModelAsControllerWithCustomPathView.class)
 					.load();
 		} catch (RuntimeException e){
-			assertThat(e.getCause().getCause().getMessage())
+			assertThat(ExceptionUtils.getRootCause(e)).isInstanceOf(IllegalStateException.class);
+			assertThat(ExceptionUtils.getRootCause(e).getMessage())
 					.contains("A ViewModel class")
 					.contains("was referenced in the FXML file")
 					.contains("as the fx:controller");
@@ -571,7 +574,8 @@ public class FluentViewLoader_FxmlView_Test {
 					.viewModel(new TestFxmlViewModelAsControllerWithCustomPathViewModel())
 					.load();
 		} catch (RuntimeException e){
-			assertThat(e.getCause().getCause().getMessage())
+			assertThat(ExceptionUtils.getRootCause(e)).isInstanceOf(IllegalStateException.class);
+			assertThat(ExceptionUtils.getRootCause(e).getMessage())
 					.contains("A ViewModel class")
 					.contains("was referenced in the FXML file")
 					.contains("as the fx:controller");

--- a/mvvmfx/src/test/java/de/saxsys/mvvmfx/internal/viewloader/FluentViewLoader_FxmlView_Test.java
+++ b/mvvmfx/src/test/java/de/saxsys/mvvmfx/internal/viewloader/FluentViewLoader_FxmlView_Test.java
@@ -564,7 +564,7 @@ public class FluentViewLoader_FxmlView_Test {
 			assertThat(ExceptionUtils.getRootCause(e)).isInstanceOf(IllegalStateException.class);
 			assertThat(ExceptionUtils.getRootCause(e))
 					.hasMessageContaining("A ViewModel class")
-					.hasMessageContaining("was referenced in the FXML file")
+					.hasMessageContaining("was referenced in an FXML file")
 					.hasMessageContaining("as the fx:controller");
 		}
 
@@ -577,9 +577,36 @@ public class FluentViewLoader_FxmlView_Test {
 			assertThat(ExceptionUtils.getRootCause(e)).isInstanceOf(IllegalStateException.class);
 			assertThat(ExceptionUtils.getRootCause(e))
 					.hasMessageContaining("A ViewModel class")
-					.hasMessageContaining("was referenced in the FXML file")
+					.hasMessageContaining("was referenced in an FXML file")
 					.hasMessageContaining("as the fx:controller");
 		}
 
+	}
+
+	@Test
+	public void testFxmlViewModelAsControllerFxInclude(){
+		try {
+			FluentViewLoader.fxmlView(TestFxmlViewModelAsControllerParent.class)
+					.load();
+		} catch (RuntimeException e){
+			assertThat(ExceptionUtils.getRootCause(e)).isInstanceOf(IllegalStateException.class);
+			assertThat(ExceptionUtils.getRootCause(e))
+					.hasMessageContaining("A ViewModel class")
+					.hasMessageContaining("was referenced in an FXML file")
+					.hasMessageContaining("as the fx:controller");
+		}
+
+		//with ControllerFactoryWithCustomViewModel
+		try {
+			FluentViewLoader.fxmlView(TestFxmlViewModelAsControllerParent.class)
+					.viewModel(new TestFxmlViewModelAsControllerParentViewModel())
+					.load();
+		} catch (RuntimeException e){
+			assertThat(ExceptionUtils.getRootCause(e)).isInstanceOf(IllegalStateException.class);
+			assertThat(ExceptionUtils.getRootCause(e))
+					.hasMessageContaining("A ViewModel class")
+					.hasMessageContaining("was referenced in an FXML file")
+					.hasMessageContaining("as the fx:controller");
+		}
 	}
 }

--- a/mvvmfx/src/test/java/de/saxsys/mvvmfx/internal/viewloader/FluentViewLoader_FxmlView_Test.java
+++ b/mvvmfx/src/test/java/de/saxsys/mvvmfx/internal/viewloader/FluentViewLoader_FxmlView_Test.java
@@ -531,20 +531,51 @@ public class FluentViewLoader_FxmlView_Test {
 	@Test
 	public void testFxmlViewModelAsControllerException(){
 		try {
-			ViewTuple<TestFxmlViewModelAsController, TestFxmlViewModelAsControllerViewModel> load = FluentViewLoader
-					.fxmlView(TestFxmlViewModelAsController.class).load();
-		} catch (IllegalStateException e){
-			assertThat(e.getMessage()).contains("A ViewModel class").contains("was referenced in the FXML file").contains("as the fx:controller");
+			FluentViewLoader.fxmlView(TestFxmlViewModelAsController.class)
+					.load();
+		} catch (RuntimeException e){ ;
+			assertThat(e.getCause().getCause().getMessage())
+					.contains("A ViewModel class")
+					.contains("was referenced in the FXML file")
+					.contains("as the fx:controller");
+		}
+
+		//with ControllerFactoryWithCustomViewModel
+		try {
+			FluentViewLoader.fxmlView(TestFxmlViewModelAsController.class)
+					.viewModel(new TestFxmlViewModelAsControllerViewModel())
+					.load();
+		} catch (RuntimeException e){ ;
+			assertThat(e.getCause().getCause().getMessage())
+					.contains("A ViewModel class")
+					.contains("was referenced in the FXML file")
+					.contains("as the fx:controller");
 		}
 	}
 
 	@Test
 	public void testFxmlViewModelAsControllerWithCustomPath(){
 		try {
-			ViewTuple<TestFxmlViewModelAsControllerWithCustomPathView, TestFxmlViewModelAsControllerWithCustomPathViewModel> load = FluentViewLoader
-					.fxmlView(TestFxmlViewModelAsControllerWithCustomPathView.class).load();
-		} catch (IllegalStateException e){
-			assertThat(e.getMessage()).contains("A ViewModel class").contains("was referenced in the FXML file").contains("as the fx:controller");
+			FluentViewLoader.fxmlView(TestFxmlViewModelAsControllerWithCustomPathView.class)
+					.load();
+		} catch (RuntimeException e){
+			assertThat(e.getCause().getCause().getMessage())
+					.contains("A ViewModel class")
+					.contains("was referenced in the FXML file")
+					.contains("as the fx:controller");
 		}
+
+		//with ControllerFactoryWithCustomViewModel
+		try {
+			FluentViewLoader.fxmlView(TestFxmlViewModelAsControllerWithCustomPathView.class)
+					.viewModel(new TestFxmlViewModelAsControllerWithCustomPathViewModel())
+					.load();
+		} catch (RuntimeException e){
+			assertThat(e.getCause().getCause().getMessage())
+					.contains("A ViewModel class")
+					.contains("was referenced in the FXML file")
+					.contains("as the fx:controller");
+		}
+
 	}
 }

--- a/mvvmfx/src/test/java/de/saxsys/mvvmfx/internal/viewloader/FluentViewLoader_FxmlView_Test.java
+++ b/mvvmfx/src/test/java/de/saxsys/mvvmfx/internal/viewloader/FluentViewLoader_FxmlView_Test.java
@@ -540,11 +540,11 @@ public class FluentViewLoader_FxmlView_Test {
 
 	@Test
 	public void testFxmlViewModelAsControllerWithCustomPath(){
-		ViewTuple<TestFxmlViewModelAsControllerWithCustomPath, TestFxmlViewModelAsControllerWithCustomPathViewModel> load = FluentViewLoader
-				.fxmlView(TestFxmlViewModelAsControllerWithCustomPath.class).load();
-
-		//should work since the View points to another FXML through @FxmlPath
-		assertThat(load.getView()).isNotNull().isInstanceOf(VBox.class);
-		System.out.println("test");
+		try {
+			ViewTuple<TestFxmlViewModelAsControllerWithCustomPathView, TestFxmlViewModelAsControllerWithCustomPathViewModel> load = FluentViewLoader
+					.fxmlView(TestFxmlViewModelAsControllerWithCustomPathView.class).load();
+		} catch (IllegalStateException e){
+			assertThat(e.getMessage()).contains("A ViewModel class").contains("was referenced in the FXML file").contains("as the fx:controller");
+		}
 	}
 }

--- a/mvvmfx/src/test/java/de/saxsys/mvvmfx/internal/viewloader/example/TestFxmlViewModelAsController.java
+++ b/mvvmfx/src/test/java/de/saxsys/mvvmfx/internal/viewloader/example/TestFxmlViewModelAsController.java
@@ -1,0 +1,13 @@
+package de.saxsys.mvvmfx.internal.viewloader.example;
+
+import de.saxsys.mvvmfx.FxmlPath;
+import de.saxsys.mvvmfx.FxmlView;
+import de.saxsys.mvvmfx.InjectViewModel;
+import de.saxsys.mvvmfx.internal.viewloader.View;
+
+public class TestFxmlViewModelAsController implements FxmlView<TestFxmlViewModelAsControllerViewModel> {
+
+	@InjectViewModel
+	TestFxmlViewModelAsControllerViewModel viewModel;
+
+}

--- a/mvvmfx/src/test/java/de/saxsys/mvvmfx/internal/viewloader/example/TestFxmlViewModelAsControllerChild.java
+++ b/mvvmfx/src/test/java/de/saxsys/mvvmfx/internal/viewloader/example/TestFxmlViewModelAsControllerChild.java
@@ -1,0 +1,6 @@
+package de.saxsys.mvvmfx.internal.viewloader.example;
+
+import de.saxsys.mvvmfx.FxmlView;
+
+public class TestFxmlViewModelAsControllerChild implements FxmlView{
+}

--- a/mvvmfx/src/test/java/de/saxsys/mvvmfx/internal/viewloader/example/TestFxmlViewModelAsControllerChildViewModel.java
+++ b/mvvmfx/src/test/java/de/saxsys/mvvmfx/internal/viewloader/example/TestFxmlViewModelAsControllerChildViewModel.java
@@ -1,0 +1,6 @@
+package de.saxsys.mvvmfx.internal.viewloader.example;
+
+import de.saxsys.mvvmfx.ViewModel;
+
+public class TestFxmlViewModelAsControllerChildViewModel implements ViewModel{
+}

--- a/mvvmfx/src/test/java/de/saxsys/mvvmfx/internal/viewloader/example/TestFxmlViewModelAsControllerParent.java
+++ b/mvvmfx/src/test/java/de/saxsys/mvvmfx/internal/viewloader/example/TestFxmlViewModelAsControllerParent.java
@@ -1,0 +1,6 @@
+package de.saxsys.mvvmfx.internal.viewloader.example;
+
+import de.saxsys.mvvmfx.FxmlView;
+
+public class TestFxmlViewModelAsControllerParent implements FxmlView<TestFxmlViewModelAsControllerParentViewModel>{
+}

--- a/mvvmfx/src/test/java/de/saxsys/mvvmfx/internal/viewloader/example/TestFxmlViewModelAsControllerParentViewModel.java
+++ b/mvvmfx/src/test/java/de/saxsys/mvvmfx/internal/viewloader/example/TestFxmlViewModelAsControllerParentViewModel.java
@@ -1,0 +1,6 @@
+package de.saxsys.mvvmfx.internal.viewloader.example;
+
+import de.saxsys.mvvmfx.ViewModel;
+
+public class TestFxmlViewModelAsControllerParentViewModel implements ViewModel{
+}

--- a/mvvmfx/src/test/java/de/saxsys/mvvmfx/internal/viewloader/example/TestFxmlViewModelAsControllerViewModel.java
+++ b/mvvmfx/src/test/java/de/saxsys/mvvmfx/internal/viewloader/example/TestFxmlViewModelAsControllerViewModel.java
@@ -1,0 +1,6 @@
+package de.saxsys.mvvmfx.internal.viewloader.example;
+
+import de.saxsys.mvvmfx.ViewModel;
+
+public class TestFxmlViewModelAsControllerViewModel implements ViewModel {
+}

--- a/mvvmfx/src/test/java/de/saxsys/mvvmfx/internal/viewloader/example/TestFxmlViewModelAsControllerWithCustomPath.java
+++ b/mvvmfx/src/test/java/de/saxsys/mvvmfx/internal/viewloader/example/TestFxmlViewModelAsControllerWithCustomPath.java
@@ -1,0 +1,8 @@
+package de.saxsys.mvvmfx.internal.viewloader.example;
+
+import de.saxsys.mvvmfx.FxmlPath;
+import de.saxsys.mvvmfx.FxmlView;
+
+@FxmlPath("/de/saxsys/mvvmfx/internal/viewloader/example/TestFxmlViewWithCustomPath.fxml")
+public class TestFxmlViewModelAsControllerWithCustomPath implements FxmlView<TestFxmlViewModelAsControllerWithCustomPathViewModel> {
+}

--- a/mvvmfx/src/test/java/de/saxsys/mvvmfx/internal/viewloader/example/TestFxmlViewModelAsControllerWithCustomPath.java
+++ b/mvvmfx/src/test/java/de/saxsys/mvvmfx/internal/viewloader/example/TestFxmlViewModelAsControllerWithCustomPath.java
@@ -1,8 +1,0 @@
-package de.saxsys.mvvmfx.internal.viewloader.example;
-
-import de.saxsys.mvvmfx.FxmlPath;
-import de.saxsys.mvvmfx.FxmlView;
-
-@FxmlPath("/de/saxsys/mvvmfx/internal/viewloader/example/TestFxmlViewWithCustomPath.fxml")
-public class TestFxmlViewModelAsControllerWithCustomPath implements FxmlView<TestFxmlViewModelAsControllerWithCustomPathViewModel> {
-}

--- a/mvvmfx/src/test/java/de/saxsys/mvvmfx/internal/viewloader/example/TestFxmlViewModelAsControllerWithCustomPathView.java
+++ b/mvvmfx/src/test/java/de/saxsys/mvvmfx/internal/viewloader/example/TestFxmlViewModelAsControllerWithCustomPathView.java
@@ -1,0 +1,8 @@
+package de.saxsys.mvvmfx.internal.viewloader.example;
+
+import de.saxsys.mvvmfx.FxmlPath;
+import de.saxsys.mvvmfx.FxmlView;
+
+@FxmlPath("/de/saxsys/mvvmfx/internal/viewloader/example/TestFxmlViewModelAsControllerWithCustomPath.fxml")
+public class TestFxmlViewModelAsControllerWithCustomPathView implements FxmlView<TestFxmlViewModelAsControllerWithCustomPathViewModel> {
+}

--- a/mvvmfx/src/test/java/de/saxsys/mvvmfx/internal/viewloader/example/TestFxmlViewModelAsControllerWithCustomPathViewModel.java
+++ b/mvvmfx/src/test/java/de/saxsys/mvvmfx/internal/viewloader/example/TestFxmlViewModelAsControllerWithCustomPathViewModel.java
@@ -1,0 +1,6 @@
+package de.saxsys.mvvmfx.internal.viewloader.example;
+
+import de.saxsys.mvvmfx.ViewModel;
+
+public class TestFxmlViewModelAsControllerWithCustomPathViewModel implements ViewModel{
+}

--- a/mvvmfx/src/test/resources/de/saxsys/mvvmfx/internal/viewloader/example/TestFxmlViewModelAsController.fxml
+++ b/mvvmfx/src/test/resources/de/saxsys/mvvmfx/internal/viewloader/example/TestFxmlViewModelAsController.fxml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import java.lang.*?>
+<?import java.util.*?>
+<?import javafx.scene.*?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
+
+<AnchorPane xmlns="http://javafx.com/javafx"
+            xmlns:fx="http://javafx.com/fxml"
+            fx:controller="de.saxsys.mvvmfx.internal.viewloader.example.TestFxmlViewModelAsControllerViewModel"
+            prefHeight="400.0" prefWidth="600.0">
+
+</AnchorPane>

--- a/mvvmfx/src/test/resources/de/saxsys/mvvmfx/internal/viewloader/example/TestFxmlViewModelAsControllerChild.fxml
+++ b/mvvmfx/src/test/resources/de/saxsys/mvvmfx/internal/viewloader/example/TestFxmlViewModelAsControllerChild.fxml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import java.lang.*?>
+<?import java.util.*?>
+<?import javafx.scene.*?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
+
+<AnchorPane xmlns="http://javafx.com/javafx"
+            xmlns:fx="http://javafx.com/fxml"
+            fx:controller="de.saxsys.mvvmfx.internal.viewloader.example.TestFxmlViewModelAsControllerChildViewModel"
+            prefHeight="400.0" prefWidth="600.0">
+
+</AnchorPane>

--- a/mvvmfx/src/test/resources/de/saxsys/mvvmfx/internal/viewloader/example/TestFxmlViewModelAsControllerParent.fxml
+++ b/mvvmfx/src/test/resources/de/saxsys/mvvmfx/internal/viewloader/example/TestFxmlViewModelAsControllerParent.fxml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import java.lang.*?>
+<?import java.util.*?>
+<?import javafx.scene.*?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
+
+<AnchorPane xmlns="http://javafx.com/javafx"
+            xmlns:fx="http://javafx.com/fxml"
+            fx:controller="de.saxsys.mvvmfx.internal.viewloader.example.TestFxmlViewModelAsControllerParent"
+            prefHeight="400.0" prefWidth="600.0">
+    <children>
+        <fx:include source="TestFxmlViewModelAsControllerChild.fxml"/>
+    </children>
+</AnchorPane>

--- a/mvvmfx/src/test/resources/de/saxsys/mvvmfx/internal/viewloader/example/TestFxmlViewModelAsControllerWithCustomPath.fxml
+++ b/mvvmfx/src/test/resources/de/saxsys/mvvmfx/internal/viewloader/example/TestFxmlViewModelAsControllerWithCustomPath.fxml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import java.lang.*?>
+<?import java.util.*?>
+<?import javafx.scene.*?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
+
+<AnchorPane xmlns="http://javafx.com/javafx"
+            xmlns:fx="http://javafx.com/fxml"
+            fx:controller="de.saxsys.mvvmfx.internal.viewloader.example.TestFxmlViewModelAsControllerWithCustomPathViewModel"
+            prefHeight="400.0" prefWidth="600.0">
+
+</AnchorPane>


### PR DESCRIPTION
#498 if the ViewModel class is defined in an fxml file, the framework will throw an exception.

It is not possible to know which FXML is the cause of the exception. This is because the FxmlLoader calls the ControllerFactories and no information is known on which fxml is trying to be loaded.