### PR TITLE
#539 Potential bug in ValidationVisualizerBase

### DIFF
--- a/mvvmfx-validation/src/main/java/de/saxsys/mvvmfx/utils/validation/visualization/ValidationVisualizerBase.java
+++ b/mvvmfx-validation/src/main/java/de/saxsys/mvvmfx/utils/validation/visualization/ValidationVisualizerBase.java
@@ -46,11 +46,12 @@ public abstract class ValidationVisualizerBase implements ValidationVisualizer {
 		}
 		
 		applyVisualization(control, result.getHighestMessage(), required);
-		
+
+		// Monitor the message list and always display the highest message.
+		// Note: there could be more than one change on the message list, but only the highest
+		// message is of interest in this case.
 		result.getMessages().addListener((ListChangeListener<ValidationMessage>) c -> {
-			while (c.next()) {
-				Platform.runLater(() -> applyVisualization(control, result.getHighestMessage(), required));
-			}
+			Platform.runLater(() -> applyVisualization(control, result.getHighestMessage(), required));
 		});
 	}
 	


### PR DESCRIPTION
In my original analysis, I thought that if we were looping on changes, we should be doing something with each change object "c".

After further analysis, I have determined that the while loop isn't necessary.  The purpose of the change listener is to update the validation message on the UI. Therefore, it only needs to be updated once with the highest priority message.

Conclusion: Removed the while loop.