### PR TITLE
#538 Using ControlsFxVisualizer causes node graph inconsistencies

### DIFF
--- a/examples/contacts-example/src/main/java/de/saxsys/mvvmfx/examples/contacts/ui/main/MainViewModel.java
+++ b/examples/contacts-example/src/main/java/de/saxsys/mvvmfx/examples/contacts/ui/main/MainViewModel.java
@@ -4,7 +4,7 @@ import de.saxsys.mvvmfx.ScopeProvider;
 import de.saxsys.mvvmfx.ViewModel;
 import de.saxsys.mvvmfx.examples.contacts.ui.scopes.MasterDetailScope;
 
-@ScopeProvider(scopes = MasterDetailScope.class)
+@ScopeProvider(MasterDetailScope.class)
 public class MainViewModel implements ViewModel {
 
 }

--- a/mvvmfx-testing-utils/src/main/java/de/saxsys/mvvmfx/testingutils/FxTestingUtils.java
+++ b/mvvmfx-testing-utils/src/main/java/de/saxsys/mvvmfx/testingutils/FxTestingUtils.java
@@ -2,7 +2,11 @@ package de.saxsys.mvvmfx.testingutils;
 
 import javafx.application.Platform;
 
-import java.util.concurrent.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.Semaphore;
 
 public class FxTestingUtils {
 

--- a/mvvmfx-testing-utils/src/main/java/de/saxsys/mvvmfx/testingutils/FxTestingUtils.java
+++ b/mvvmfx-testing-utils/src/main/java/de/saxsys/mvvmfx/testingutils/FxTestingUtils.java
@@ -2,10 +2,7 @@ package de.saxsys.mvvmfx.testingutils;
 
 import javafx.application.Platform;
 
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
+import java.util.concurrent.*;
 
 public class FxTestingUtils {
 
@@ -43,5 +40,36 @@ public class FxTestingUtils {
 	 */
 	public static void waitForUiThread() {
 		waitForUiThread(1000);
+	}
+
+	/**
+	 * This method is used to put the platform thread on hold. In conjunction with waitForUiThread(), it
+	 * allows to test that tasks are being queued on the thread.
+	 *
+	 * For example:
+	 * <pre>
+	 * {@code
+	 * cut.usePlatformRunLaterToDoSomething(...);
+	 * Semaphore semaphore = new Semaphore(0);
+	 * FxTestingUtils.putPlatformThreadOnHold(semaphore);
+	 * Mockito.verifyZeroInteractions(testDummy); // confirms runLater is being used
+	 * semaphore.release();
+	 * FxTestingUtils.waitForUiThread();
+	 * Mockito.verify(testDummy).doSomething();
+	 * }
+	 * </pre>
+	 *
+
+	 * @param semaphore
+	 * @throws InterruptedException
+	 */
+	public static void putPlatformThreadOnHold(Semaphore semaphore) throws InterruptedException {
+		Platform.runLater(() -> {
+			try {
+				semaphore.acquire();
+			} catch (InterruptedException e) {
+				e.printStackTrace();
+			}
+		});
 	}
 }

--- a/mvvmfx-validation/src/main/java/de/saxsys/mvvmfx/utils/validation/visualization/ValidationVisualizerBase.java
+++ b/mvvmfx-validation/src/main/java/de/saxsys/mvvmfx/utils/validation/visualization/ValidationVisualizerBase.java
@@ -41,16 +41,18 @@ public abstract class ValidationVisualizerBase implements ValidationVisualizer {
 	
 	@Override
 	public void initVisualization(final ValidationStatus result, final Control control, boolean required) {
-		if (required) {
-			applyRequiredVisualization(control, required);
-		}
-		
-		applyVisualization(control, result.getHighestMessage(), required);
-		
-		result.getMessages().addListener((ListChangeListener<ValidationMessage>) c -> {
-			while (c.next()) {
-				Platform.runLater(() -> applyVisualization(control, result.getHighestMessage(), required));
+		Platform.runLater(() -> {
+			if (required) {
+				applyRequiredVisualization(control, required);
 			}
+
+			applyVisualization(control, result.getHighestMessage(), required);
+
+			result.getMessages().addListener((ListChangeListener<ValidationMessage>) c -> {
+				while (c.next()) {
+					Platform.runLater(() -> applyVisualization(control, result.getHighestMessage(), required));
+				}
+			});
 		});
 	}
 	

--- a/mvvmfx-validation/src/main/java/de/saxsys/mvvmfx/utils/validation/visualization/ValidationVisualizerBase.java
+++ b/mvvmfx-validation/src/main/java/de/saxsys/mvvmfx/utils/validation/visualization/ValidationVisualizerBase.java
@@ -37,8 +37,8 @@ import java.util.Optional;
  * @author manuel.mauky
  */
 public abstract class ValidationVisualizerBase implements ValidationVisualizer {
-	
-	
+
+
 	@Override
 	public void initVisualization(final ValidationStatus result, final Control control, boolean required) {
 		Platform.runLater(() -> {

--- a/mvvmfx-validation/src/main/java/de/saxsys/mvvmfx/utils/validation/visualization/ValidationVisualizerBase.java
+++ b/mvvmfx-validation/src/main/java/de/saxsys/mvvmfx/utils/validation/visualization/ValidationVisualizerBase.java
@@ -48,11 +48,11 @@ public abstract class ValidationVisualizerBase implements ValidationVisualizer {
 
 			applyVisualization(control, result.getHighestMessage(), required);
 
-    	// Monitor the message list and always display the highest message.
-	  	// Note: there could be more than one change on the message list, but only the highest
-  		// message is of interest in this case.
+			// Monitor the message list and always display the highest message.
+			// Note: there could be more than one change on the message list, but only the highest
+			// message is of interest in this case.
 			result.getMessages().addListener((ListChangeListener<ValidationMessage>) c -> {
-					Platform.runLater(() -> applyVisualization(control, result.getHighestMessage(), required));
+				Platform.runLater(() -> applyVisualization(control, result.getHighestMessage(), required));
 			});
 		});
 	}

--- a/mvvmfx-validation/src/test/java/de/saxsys/mvvmfx/utils/validation/visualization/ValidationVisualizerBaseTest.java
+++ b/mvvmfx-validation/src/test/java/de/saxsys/mvvmfx/utils/validation/visualization/ValidationVisualizerBaseTest.java
@@ -1,0 +1,106 @@
+package de.saxsys.mvvmfx.utils.validation.visualization;
+
+import de.saxsys.mvvmfx.testingutils.FxTestingUtils;
+import de.saxsys.mvvmfx.testingutils.JfxToolkitExtension;
+import de.saxsys.mvvmfx.utils.validation.ValidationMessage;
+import de.saxsys.mvvmfx.utils.validation.ValidationStatus;
+import javafx.collections.ListChangeListener;
+import javafx.collections.ObservableList;
+import javafx.scene.control.Control;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Optional;
+import java.util.concurrent.Semaphore;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(JfxToolkitExtension.class)
+class ValidationVisualizerBaseTest {
+
+    ValidationVisualizerBase cut;
+
+    @Mock
+    private ValidationStatus validationStatus;
+
+    @Mock
+    private Control control;
+
+    // Can't Mock Optional final class
+    @Mock
+    private ValidationMessage highestMessageValue;
+    private Optional<ValidationMessage> highestMessage;
+
+    @Mock
+    private ObservableList<ValidationMessage> messages;
+
+    interface TestDummy {
+        void applyRequiredVisualization(Control control, boolean required);
+        void applyVisualization(Control control, Optional<ValidationMessage> messageOptional, boolean required);
+    }
+
+    @Mock
+    TestDummy testDummy;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.initMocks(this);
+        highestMessage = Optional.of(highestMessageValue); // cant mock optional final class
+
+        cut = new ValidationVisualizerBase() {
+            @Override
+            void applyRequiredVisualization(Control control, boolean required) {
+                testDummy.applyRequiredVisualization(control, required);
+            }
+
+            @Override
+            void applyVisualization(Control control, Optional<ValidationMessage> messageOptional, boolean required) {
+                testDummy.applyVisualization(control, messageOptional, required);
+            }
+        };
+
+        Mockito.when(validationStatus.getHighestMessage()).thenReturn(highestMessage);
+        Mockito.when(validationStatus.getMessages()).thenReturn(messages);
+
+    }
+
+    /*
+    This test validates that initialization code is executed later on the Platform thread.
+    The reason this must happen is that the initialization function can be called while the
+    node graph is still being built. Adding Visualizer nodes during initialization can cause
+    inconsistencies depending on when that happens. Running this code later ensures all
+    initialization is completed before the visualizers are added.
+     */
+    @Test
+    void testDelayedInitialization() throws InterruptedException {
+        boolean required = true;
+        cut.initVisualization(validationStatus, control, required);
+        Semaphore semaphore = new Semaphore(0);
+        FxTestingUtils.putPlatformThreadOnHold(semaphore);
+        Mockito.verifyZeroInteractions(testDummy);
+        semaphore.release();
+        FxTestingUtils.waitForUiThread();
+        Mockito.verify(testDummy).applyRequiredVisualization(control, required);
+        Mockito.verify(testDummy).applyVisualization(control, highestMessage, required);
+        Mockito.verify(messages).addListener(Mockito.any(ListChangeListener.class));
+    }
+
+    @Test
+    void testDelayedInitializationWithRequiredFalse() throws InterruptedException {
+        boolean required = false;
+        cut.initVisualization(validationStatus, control, required);
+        Semaphore semaphore = new Semaphore(0);
+        FxTestingUtils.putPlatformThreadOnHold(semaphore);
+        Mockito.verifyZeroInteractions(testDummy);
+        semaphore.release();
+        FxTestingUtils.waitForUiThread();
+        Mockito.verify(testDummy, never()).applyRequiredVisualization(control, required);
+        Mockito.verify(testDummy).applyVisualization(control, highestMessage, required);
+        Mockito.verify(messages).addListener(Mockito.any(ListChangeListener.class));
+    }
+}

--- a/mvvmfx/src/main/java/de/saxsys/mvvmfx/ScopeProvider.java
+++ b/mvvmfx/src/main/java/de/saxsys/mvvmfx/ScopeProvider.java
@@ -9,12 +9,12 @@ import java.lang.annotation.Target;
 @Target(ElementType.TYPE)
 public @interface ScopeProvider {
 	/**
-	 * The scopes provides by this scope provider.
+	 * The scopes provided by this scope provider.
 	 */
     Class<? extends Scope>[] scopes() default {};
     
     /**
-	 * The scopes provides by this scope provider. This is an alias for {@link #scopes()}. 
+	 * The scopes provided by this scope provider. This is an alias for {@link #scopes()}. 
 	 * If both {@link #value()} and {@link #scopes()} are provided, the content of
 	 * {@link #value()} is preferred.
 	 */

--- a/mvvmfx/src/main/java/de/saxsys/mvvmfx/ScopeProvider.java
+++ b/mvvmfx/src/main/java/de/saxsys/mvvmfx/ScopeProvider.java
@@ -8,5 +8,15 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 public @interface ScopeProvider {
-    Class<? extends Scope>[] scopes();
+	/**
+	 * The scopes provides by this scope provider.
+	 */
+    Class<? extends Scope>[] scopes() default {};
+    
+    /**
+	 * The scopes provides by this scope provider. This is an alias for {@link #scopes()}. 
+	 * If both {@link #value()} and {@link #scopes()} are provided, the content of
+	 * {@link #value()} is preferred.
+	 */
+    Class<? extends Scope>[] value() default {};
 }

--- a/mvvmfx/src/main/java/de/saxsys/mvvmfx/internal/viewloader/ViewLoaderReflectionUtils.java
+++ b/mvvmfx/src/main/java/de/saxsys/mvvmfx/internal/viewloader/ViewLoaderReflectionUtils.java
@@ -282,7 +282,7 @@ public class ViewLoaderReflectionUtils {
         for (Annotation annotation : viewModelClass.getDeclaredAnnotations()) {
             if (annotation.annotationType().isAssignableFrom(ScopeProvider.class)) {
                 ScopeProvider provider = (ScopeProvider) annotation;
-                Class<? extends Scope>[] scopes = getScopesFromProvider( provider, viewModelClass );
+                Class<? extends Scope>[] scopes = getScopesFromProvider(provider, viewModelClass);
                 for (int i = 0; i < scopes.length; i++) {
                     Class<? extends Scope> scopeType = scopes[i];
                     // Overrides existing scopes!!!!
@@ -300,20 +300,20 @@ public class ViewLoaderReflectionUtils {
         });
     }
 
-	private static Class<? extends Scope>[] getScopesFromProvider( final ScopeProvider scopeProvider, final Class<?> aViewModelClass ) {
-		Class<? extends Scope>[] scopes = scopeProvider.value( );
-		
-		if (scopes.length == 0) {
-			scopes = scopeProvider.scopes( );
-		}
-		
-		if (scopes.length == 0) {
-			final String message = String.format( "The scope provider '%s' has to provide at least one scope.", aViewModelClass.getCanonicalName( ) );
-			throw new IllegalArgumentException( message );
-		}
-		
-		return scopes;
-	}
+    private static Class<? extends Scope>[] getScopesFromProvider(final ScopeProvider scopeProvider, final Class<?> aViewModelClass) {
+        Class<? extends Scope>[] scopes = scopeProvider.value();
+        
+        if (scopes.length == 0) {
+            scopes = scopeProvider.scopes();
+        }
+        
+        if (scopes.length == 0) {
+            final String message = String.format("The scope provider '%s' has to provide at least one scope.", aViewModelClass.getCanonicalName());
+            throw new IllegalArgumentException(message);
+        }
+
+        return scopes;
+    }
 
     public static void injectContext(View codeBehind, ContextImpl context) {
 

--- a/mvvmfx/src/main/java/de/saxsys/mvvmfx/internal/viewloader/ViewLoaderReflectionUtils.java
+++ b/mvvmfx/src/main/java/de/saxsys/mvvmfx/internal/viewloader/ViewLoaderReflectionUtils.java
@@ -32,8 +32,6 @@ import javax.annotation.PostConstruct;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -284,7 +282,7 @@ public class ViewLoaderReflectionUtils {
         for (Annotation annotation : viewModelClass.getDeclaredAnnotations()) {
             if (annotation.annotationType().isAssignableFrom(ScopeProvider.class)) {
                 ScopeProvider provider = (ScopeProvider) annotation;
-                Class<? extends Scope>[] scopes = provider.scopes();
+                Class<? extends Scope>[] scopes = getScopesFromProvider( provider, viewModelClass );
                 for (int i = 0; i < scopes.length; i++) {
                     Class<? extends Scope> scopeType = scopes[i];
                     // Overrides existing scopes!!!!
@@ -301,6 +299,21 @@ public class ViewLoaderReflectionUtils {
                     "Can't inject Scope into ViewModel <" + viewModel.getClass() + ">");
         });
     }
+
+	private static Class<? extends Scope>[] getScopesFromProvider( final ScopeProvider scopeProvider, final Class<?> aViewModelClass ) {
+		Class<? extends Scope>[] scopes = scopeProvider.value( );
+		
+		if (scopes.length == 0) {
+			scopes = scopeProvider.scopes( );
+		}
+		
+		if (scopes.length == 0) {
+			final String message = String.format( "The scope provider '%s' has to provide at least one scope.", aViewModelClass.getCanonicalName( ) );
+			throw new IllegalArgumentException( message );
+		}
+		
+		return scopes;
+	}
 
     public static void injectContext(View codeBehind, ContextImpl context) {
 
@@ -332,8 +345,8 @@ public class ViewLoaderReflectionUtils {
         if (newScope == null) {
             // TODO Modify Stacktrace to get the Injectionpoint of the Scope
             throw new IllegalStateException(
-                    "A scope was requested but no @ScopeProvider found in the hirarchy. Declare it like this: @ScopeProvider("
-                            + scopeType.getName() + ")");
+                    "A scope was requested but no @ScopeProvider found in the hierarchy. Declare it like this: @ScopeProvider("
+                            + scopeType.getName() + ".class )");
         }
 
         if (!newScope.getClass().equals(scopeType)) {


### PR DESCRIPTION
Wrapped ValidationVisualizationBase in a Platform.runLater to ensure the node graph completes initialization before any Visualizers are created on top of it.

Added a test class.

Added a utility function that allows to pause the Platform thread in order to allow the test code to validate whether or not a function is using runLater.   Pausing the thread is required since it is possible that the Runnable be executed before the test has had the time to validate.