### PR TITLE
[#543] Incorrect exception message in ViewLoaderReflectionUtils

### DIFF
--- a/examples/contacts-example/src/main/java/de/saxsys/mvvmfx/examples/contacts/ui/main/MainViewModel.java
+++ b/examples/contacts-example/src/main/java/de/saxsys/mvvmfx/examples/contacts/ui/main/MainViewModel.java
@@ -4,7 +4,7 @@ import de.saxsys.mvvmfx.ScopeProvider;
 import de.saxsys.mvvmfx.ViewModel;
 import de.saxsys.mvvmfx.examples.contacts.ui.scopes.MasterDetailScope;
 
-@ScopeProvider(scopes = MasterDetailScope.class)
+@ScopeProvider(MasterDetailScope.class)
 public class MainViewModel implements ViewModel {
 
 }

--- a/mvvmfx/src/main/java/de/saxsys/mvvmfx/ScopeProvider.java
+++ b/mvvmfx/src/main/java/de/saxsys/mvvmfx/ScopeProvider.java
@@ -9,12 +9,12 @@ import java.lang.annotation.Target;
 @Target(ElementType.TYPE)
 public @interface ScopeProvider {
 	/**
-	 * The scopes provides by this scope provider.
+	 * The scopes provided by this scope provider.
 	 */
     Class<? extends Scope>[] scopes() default {};
     
     /**
-	 * The scopes provides by this scope provider. This is an alias for {@link #scopes()}. 
+	 * The scopes provided by this scope provider. This is an alias for {@link #scopes()}. 
 	 * If both {@link #value()} and {@link #scopes()} are provided, the content of
 	 * {@link #value()} is preferred.
 	 */

--- a/mvvmfx/src/main/java/de/saxsys/mvvmfx/ScopeProvider.java
+++ b/mvvmfx/src/main/java/de/saxsys/mvvmfx/ScopeProvider.java
@@ -8,5 +8,15 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 public @interface ScopeProvider {
-    Class<? extends Scope>[] scopes();
+	/**
+	 * The scopes provides by this scope provider.
+	 */
+    Class<? extends Scope>[] scopes() default {};
+    
+    /**
+	 * The scopes provides by this scope provider. This is an alias for {@link #scopes()}. 
+	 * If both {@link #value()} and {@link #scopes()} are provided, the content of
+	 * {@link #value()} is preferred.
+	 */
+    Class<? extends Scope>[] value() default {};
 }

--- a/mvvmfx/src/main/java/de/saxsys/mvvmfx/internal/viewloader/ViewLoaderReflectionUtils.java
+++ b/mvvmfx/src/main/java/de/saxsys/mvvmfx/internal/viewloader/ViewLoaderReflectionUtils.java
@@ -282,7 +282,7 @@ public class ViewLoaderReflectionUtils {
         for (Annotation annotation : viewModelClass.getDeclaredAnnotations()) {
             if (annotation.annotationType().isAssignableFrom(ScopeProvider.class)) {
                 ScopeProvider provider = (ScopeProvider) annotation;
-                Class<? extends Scope>[] scopes = getScopesFromProvider( provider, viewModelClass );
+                Class<? extends Scope>[] scopes = getScopesFromProvider(provider, viewModelClass);
                 for (int i = 0; i < scopes.length; i++) {
                     Class<? extends Scope> scopeType = scopes[i];
                     // Overrides existing scopes!!!!
@@ -300,20 +300,20 @@ public class ViewLoaderReflectionUtils {
         });
     }
 
-	private static Class<? extends Scope>[] getScopesFromProvider( final ScopeProvider scopeProvider, final Class<?> aViewModelClass ) {
-		Class<? extends Scope>[] scopes = scopeProvider.value( );
-		
-		if (scopes.length == 0) {
-			scopes = scopeProvider.scopes( );
-		}
-		
-		if (scopes.length == 0) {
-			final String message = String.format( "The scope provider '%s' has to provide at least one scope.", aViewModelClass.getCanonicalName( ) );
-			throw new IllegalArgumentException( message );
-		}
-		
-		return scopes;
-	}
+    private static Class<? extends Scope>[] getScopesFromProvider(final ScopeProvider scopeProvider, final Class<?> aViewModelClass) {
+        Class<? extends Scope>[] scopes = scopeProvider.value();
+        
+        if (scopes.length == 0) {
+            scopes = scopeProvider.scopes();
+        }
+        
+        if (scopes.length == 0) {
+            final String message = String.format("The scope provider '%s' has to provide at least one scope.", aViewModelClass.getCanonicalName());
+            throw new IllegalArgumentException(message);
+        }
+
+        return scopes;
+    }
 
     public static void injectContext(View codeBehind, ContextImpl context) {
 

--- a/mvvmfx/src/main/java/de/saxsys/mvvmfx/internal/viewloader/ViewLoaderReflectionUtils.java
+++ b/mvvmfx/src/main/java/de/saxsys/mvvmfx/internal/viewloader/ViewLoaderReflectionUtils.java
@@ -32,8 +32,6 @@ import javax.annotation.PostConstruct;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -284,7 +282,7 @@ public class ViewLoaderReflectionUtils {
         for (Annotation annotation : viewModelClass.getDeclaredAnnotations()) {
             if (annotation.annotationType().isAssignableFrom(ScopeProvider.class)) {
                 ScopeProvider provider = (ScopeProvider) annotation;
-                Class<? extends Scope>[] scopes = provider.scopes();
+                Class<? extends Scope>[] scopes = getScopesFromProvider( provider, viewModelClass );
                 for (int i = 0; i < scopes.length; i++) {
                     Class<? extends Scope> scopeType = scopes[i];
                     // Overrides existing scopes!!!!
@@ -301,6 +299,21 @@ public class ViewLoaderReflectionUtils {
                     "Can't inject Scope into ViewModel <" + viewModel.getClass() + ">");
         });
     }
+
+	private static Class<? extends Scope>[] getScopesFromProvider( final ScopeProvider scopeProvider, final Class<?> aViewModelClass ) {
+		Class<? extends Scope>[] scopes = scopeProvider.value( );
+		
+		if (scopes.length == 0) {
+			scopes = scopeProvider.scopes( );
+		}
+		
+		if (scopes.length == 0) {
+			final String message = String.format( "The scope provider '%s' has to provide at least one scope.", aViewModelClass.getCanonicalName( ) );
+			throw new IllegalArgumentException( message );
+		}
+		
+		return scopes;
+	}
 
     public static void injectContext(View codeBehind, ContextImpl context) {
 
@@ -332,8 +345,8 @@ public class ViewLoaderReflectionUtils {
         if (newScope == null) {
             // TODO Modify Stacktrace to get the Injectionpoint of the Scope
             throw new IllegalStateException(
-                    "A scope was requested but no @ScopeProvider found in the hirarchy. Declare it like this: @ScopeProvider("
-                            + scopeType.getName() + ")");
+                    "A scope was requested but no @ScopeProvider found in the hierarchy. Declare it like this: @ScopeProvider("
+                            + scopeType.getName() + ".class )");
         }
 
         if (!newScope.getClass().equals(scopeType)) {


### PR DESCRIPTION
This is a pull request for #543. I corrected the exception message as originally discussed. I also made sure that the ScopeProvider has _value_ as an alias for _scopes_, which is handled in the _ViewLoaderReflectionUtils_. From the two view models in the example using a scope provider, one uses now _scopes_ and the other one the _value_ field.