### PR TITLE
[#545] NotificationTestHelper should not start JavaFX thread 

### DIFF
--- a/mvvmfx/src/main/java/de/saxsys/mvvmfx/utils/notifications/ThreadlessNotificationTestHelper.java
+++ b/mvvmfx/src/main/java/de/saxsys/mvvmfx/utils/notifications/ThreadlessNotificationTestHelper.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright 2018 Nils Christian Ehmke
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package de.saxsys.mvvmfx.utils.notifications;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import javafx.util.Pair;
+
+/**
+ * The {@link ThreadlessNotificationTestHelper} is an alternative to the {@link NotificationTestHelper} and can be used
+ * to test notifications, for instance from view models. Unlike the {@link NotificationTestHelper}, this class does not
+ * use a thread and does also not rely on the JavaFX runtime environment being started. This makes this class useful in
+ * unit tests within test environments where JavaFX can not be used.</br>
+ * </br>
+ * This class implements {@link NotificationObserver}, which means that it can be added as subscriber. It records every
+ * received notification and can be queried afterwards.
+ * 
+ * @author Nils Christian Ehmke
+ * 
+ * @see NotificationTestHelper
+ */
+public class ThreadlessNotificationTestHelper implements NotificationObserver {
+
+    private final List<Pair<String, Object[]>> notifications = new ArrayList<>( );
+
+    @Override
+    public void receivedNotification(final String key, final Object... payload) {
+        notifications.add(new Pair<>(key, payload));
+    }
+
+    /**
+     * Provides an unmodifiable list containing all received notifications.
+     * 
+     * @return All received notifications.
+     */
+    public List<Pair<String, Object[]>> getReceivedNotifications() {
+        return Collections.unmodifiableList(notifications);
+    }
+
+    /**
+     * Provides the number of received notifications.
+     * 
+     * @return The number of received notifications.
+     */
+    public int numberOfReceivedNotifications() {
+        return notifications.size();
+    }
+
+    /**
+     * Provides the number of received notifications with a given key.
+     * 
+     * @param key
+     *            The key of the notification.
+     *            
+     * @return The number of received notifications with the given key.
+     */
+    public int numberOfReceivedNotifications(String key) {
+        return (int) notifications.parallelStream()
+                                  .map(Pair::getKey)
+                                  .filter(k -> k.equals(key))
+                                  .count();
+    }
+    
+    /**
+     * Clears the list of received notifications.
+     */
+    public void clear() {
+        notifications.clear();
+    }
+
+}

--- a/mvvmfx/src/test/java/de/saxsys/mvvmfx/utils/notifications/ThreadlessNotificationTestHelperTest.java
+++ b/mvvmfx/src/test/java/de/saxsys/mvvmfx/utils/notifications/ThreadlessNotificationTestHelperTest.java
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ * Copyright 2018 Nils Christian Ehmke
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package de.saxsys.mvvmfx.utils.notifications;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import javafx.util.Pair;
+
+public class ThreadlessNotificationTestHelperTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none( );
+    
+    @Test
+    public void receivedNotificationShouldStorePair() {
+        final ThreadlessNotificationTestHelper testHelper = new ThreadlessNotificationTestHelper();
+        testHelper.receivedNotification("someKey", "somePayload");
+        
+        assertThat(testHelper.numberOfReceivedNotifications()).isEqualTo(1);
+        assertThat(testHelper.getReceivedNotifications()).hasSize(1);
+        assertThat(testHelper.getReceivedNotifications().get(0).getKey()).isEqualTo("someKey");
+        assertThat(testHelper.getReceivedNotifications().get(0).getValue()[0]).isEqualTo("somePayload");
+    }
+    
+    @Test
+    public void getReceivedNotificationsShouldReturnImmutableList() {
+        final ThreadlessNotificationTestHelper testHelper = new ThreadlessNotificationTestHelper();
+        final List<Pair<String, Object[]>> list = testHelper.getReceivedNotifications();
+        
+        expectedException.expect(UnsupportedOperationException.class);
+        list.add(new Pair<String, Object[]>("someKey", new Object[] {"someValue"}));
+    }
+    
+    @Test
+    public void clearShouldRemoveAllNotifications() {
+        final ThreadlessNotificationTestHelper testHelper = new ThreadlessNotificationTestHelper();
+        testHelper.receivedNotification("someKey", "somePayload");
+        
+        testHelper.clear();
+        assertThat(testHelper.numberOfReceivedNotifications()).isEqualTo(0);
+        assertThat(testHelper.getReceivedNotifications()).isEmpty( );
+    }
+    
+    @Test
+    public void numberOfReceivedNotificationsShouldFilterCorrectly() {
+        final ThreadlessNotificationTestHelper testHelper = new ThreadlessNotificationTestHelper();
+        testHelper.receivedNotification("A", "somePayload");
+        testHelper.receivedNotification("A", "somePayload");
+        testHelper.receivedNotification("B", "somePayload");
+        
+        assertThat(testHelper.numberOfReceivedNotifications("A")).isEqualTo(2);
+        assertThat(testHelper.numberOfReceivedNotifications("B")).isEqualTo(1);
+        assertThat(testHelper.numberOfReceivedNotifications("C")).isEqualTo(0);
+    }
+    
+    
+    
+}


### PR DESCRIPTION
Hi,

This is a pull request for #545. I added a new class named _ThreadlessNotificationTestHelper_ which can be used as an alternative to the _NotificationTestHelper_. I added also some unit tests for the new class. Furthermore, I fixed the issue for an environment without any toolkit as discussed. The toolkit initializer still prints an exception (this cannot be corrected easily, as _com.sun.javafx.tk.Toolkit.getToolkit()_ simply calls _printStackTrace_), but the exception is now caught by mvvmFX and handled correctly. I tested this in a simple docker container and now the _publish_ method from the view model works even in an environment without toolkit.

Best regards

  Nils