### PR TITLE
#538 Using ControlsFxVisualizer causes node graph inconsistencies

### DIFF
--- a/mvvmfx-validation/src/main/java/de/saxsys/mvvmfx/utils/validation/visualization/ValidationVisualizerBase.java
+++ b/mvvmfx-validation/src/main/java/de/saxsys/mvvmfx/utils/validation/visualization/ValidationVisualizerBase.java
@@ -41,17 +41,19 @@ public abstract class ValidationVisualizerBase implements ValidationVisualizer {
 	
 	@Override
 	public void initVisualization(final ValidationStatus result, final Control control, boolean required) {
-		if (required) {
-			applyRequiredVisualization(control, required);
-		}
-		
-		applyVisualization(control, result.getHighestMessage(), required);
+		Platform.runLater(() -> {
+			if (required) {
+				applyRequiredVisualization(control, required);
+			}
 
-		// Monitor the message list and always display the highest message.
-		// Note: there could be more than one change on the message list, but only the highest
-		// message is of interest in this case.
-		result.getMessages().addListener((ListChangeListener<ValidationMessage>) c -> {
-			Platform.runLater(() -> applyVisualization(control, result.getHighestMessage(), required));
+			applyVisualization(control, result.getHighestMessage(), required);
+
+			// Monitor the message list and always display the highest message.
+			// Note: there could be more than one change on the message list, but only the highest
+			// message is of interest in this case.
+			result.getMessages().addListener((ListChangeListener<ValidationMessage>) c -> {
+				Platform.runLater(() -> applyVisualization(control, result.getHighestMessage(), required));
+			});
 		});
 	}
 	


### PR DESCRIPTION
The node graph problems are due to the fact the initialization code has not yet finished by the time new Validation overlays are created as nodes.  Wrapping the code in a run later ensures initialization will complete before the visualization nodes are created.