### PR TITLE
Fix the Automatic-Module-Name for mvvmfx-validation

### DIFF
--- a/mvvmfx-validation/pom.xml
+++ b/mvvmfx-validation/pom.xml
@@ -37,7 +37,7 @@
                 <configuration>
                     <archive>
                         <manifestEntries>
-                            <Automatic-Module-Name>de.saxsys.mvvmfx-validation</Automatic-Module-Name>
+                            <Automatic-Module-Name>de.saxsys.mvvmfx.validation</Automatic-Module-Name>
                         </manifestEntries>
                     </archive>
                 </configuration>


### PR DESCRIPTION
Module names should be valid package names (no hyphen characters allowed in this case). The current name with the hyphen causes a module-info.java file to fail to compile when you try to import this module.

See the spec https://cr.openjdk.java.net/~mr/jigsaw/spec/java-se-9-jls-diffs.pdf (page 192-193)